### PR TITLE
fix: Markdown images

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -22,6 +22,7 @@ declare module '@vue/runtime-core' {
     CarbonCode: typeof import('~icons/carbon/code')['default']
     CarbonEventSchedule: typeof import('~icons/carbon/event-schedule')['default']
     CarbonGameConsole: typeof import('~icons/carbon/game-console')['default']
+    CarbonHome: typeof import('~icons/carbon/home')['default']
     CarbonLink: typeof import('~icons/carbon/link')['default']
     CarbonListNumbered: typeof import('~icons/carbon/list-numbered')['default']
     CarbonLogout: typeof import('~icons/carbon/logout')['default']

--- a/src/components/ui/lazy-image.vue
+++ b/src/components/ui/lazy-image.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { MaybeElementRef, useIntersectionObserver } from '@vueuse/core';
-
 interface Props {
   cfVariant?: 'public' | 'post' | 'avatar';
   cfId?: string;
@@ -11,33 +9,21 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), { height: 400, width: 600, cfVariant: 'post' });
 
-const imgRef = ref<HTMLImageElement | null>(null);
-
-const isLoading = ref<boolean>(false);
-
-const { stop } = useIntersectionObserver(imgRef as MaybeElementRef, (entries) => {
-  const { isIntersecting } = entries[0];
-  if (!isIntersecting) return;
-  if (!imgRef.value?.dataset.src) return;
-  isLoading.value = true;
-  imgRef.value.src = imgRef.value.dataset.src;
-  stop();
-});
+const isLoading = ref<boolean>(true);
 </script>
 
 <template>
   <img
-    ref="imgRef"
-    :data-src="
+    loading="lazy"
+    :height="props.height"
+    :width="props.width"
+    :src="
       props.cfId
         ? `https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/${props.cfId}/${props.cfVariant}`
         : props.src
     "
-    :height="props.height"
-    :width="props.width"
     class="bg-gray-400"
     :class="{ 'animate-pulse': isLoading }"
-    loading="lazy"
     @load="isLoading = false"
   />
 </template>

--- a/src/pages/posts/routes/2018-07-13~2018-07-17.md
+++ b/src/pages/posts/routes/2018-07-13~2018-07-17.md
@@ -12,13 +12,13 @@ countries: [RU, KZ]
 
 비가 왔다.
 
-<ui-lazy-image cfId="961b0ac8-d5a7-477f-32c0-1dfc081c7c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/961b0ac8-d5a7-477f-32c0-1dfc081c7c00/post" />
 
 크바스를 샀다.
 
 # 2018년 7월 14일
 
-<ui-lazy-image cfId="6f8f5263-c0ee-487a-5a06-484339486900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6f8f5263-c0ee-487a-5a06-484339486900/post" />
 
 오후부터 갑자기 세찬 소나기가 내렸다.
 
@@ -26,7 +26,7 @@ countries: [RU, KZ]
 
 그냥 여기서 자기로 했다.
 
-<ui-lazy-image cfId="fb4a4028-1617-4f5b-8d18-e64d9c4e7f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/fb4a4028-1617-4f5b-8d18-e64d9c4e7f00/post" />
 
 # 2018년 7월 15일
 
@@ -58,32 +58,32 @@ Rubtsovsk에서 카자흐스탄으로 국경을 넘었다.
 
 # 2018년 7월 17일
 
-<ui-lazy-image cfId="87212a34-a289-4e17-5d34-8e9b03899400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/87212a34-a289-4e17-5d34-8e9b03899400/post" />
 
 Semey를 구경했다.
 
-<ui-lazy-image cfId="6a7d70aa-6859-4d28-c552-5c8fb783b700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6a7d70aa-6859-4d28-c552-5c8fb783b700/post" />
 
 시장에도 갔었는데
 
-<ui-lazy-image cfId="6d738657-289b-4043-5e1a-4931a2e5ed00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6d738657-289b-4043-5e1a-4931a2e5ed00/post" />
 
 사람 많은 곳은 너무 피곤한 것.
 
-<ui-lazy-image cfId="473c7859-db28-4671-7655-8b56f5106b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/473c7859-db28-4671-7655-8b56f5106b00/post" />
 
 강가는 한적한게 좋구나.
 
-<ui-lazy-image cfId="f8bd67b8-d8f8-432f-35b3-e1740507f100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f8bd67b8-d8f8-432f-35b3-e1740507f100/post" />
 
-<ui-lazy-image cfId="c3536f43-edc5-43cd-a38e-e18ed5286c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c3536f43-edc5-43cd-a38e-e18ed5286c00/post" />
 
-<ui-lazy-image cfId="32f81ce4-57ee-48fe-3148-26f8d3db2600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/32f81ce4-57ee-48fe-3148-26f8d3db2600/post" />
 
-<ui-lazy-image cfId="83346454-cea8-487d-d2d0-c681c7844500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/83346454-cea8-487d-d2d0-c681c7844500/post" />
 
-<ui-lazy-image cfId="402c627c-d016-4a62-354a-3ccf5eeccc00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/402c627c-d016-4a62-354a-3ccf5eeccc00/post" />
 
-<ui-lazy-image cfId="890375d8-a33e-4528-db11-c0720c464e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/890375d8-a33e-4528-db11-c0720c464e00/post" />
 
-<ui-lazy-image cfId="8db1f79d-82c3-4f98-bed8-d0a208e91900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8db1f79d-82c3-4f98-bed8-d0a208e91900/post" />

--- a/src/pages/posts/routes/2018-07-18~2018-07-26.md
+++ b/src/pages/posts/routes/2018-07-18~2018-07-26.md
@@ -8,81 +8,81 @@ countries: [KZ]
 
 # 2018년 7월 18일
 
-<ui-lazy-image cfId="0fb67e6e-3462-456c-a911-32d5dfc10e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0fb67e6e-3462-456c-a911-32d5dfc10e00/post" />
 
 Semey를 떠난다.
 
-<ui-lazy-image cfId="cf92dc65-5709-465a-9d0d-eb9d19980200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/cf92dc65-5709-465a-9d0d-eb9d19980200/post" />
 
 오랜만에 뒤에서 제대로 밀어주는 바람을 탔다.
 
-<ui-lazy-image cfId="6c425b0b-e47d-4e8f-7687-c92d9abc8d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6c425b0b-e47d-4e8f-7687-c92d9abc8d00/post" />
 
 자전거가 막 나가네.
 
-<ui-lazy-image cfId="c10ddf5a-2ed6-4ef6-c603-28e4b825bf00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c10ddf5a-2ed6-4ef6-c603-28e4b825bf00/post" />
 
 하지만 몽골에서의 빚을 갚으려면 이 정도로는 모자른데.
 
-<ui-lazy-image cfId="bea49c8e-7799-4aed-2120-a59eecae2800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bea49c8e-7799-4aed-2120-a59eecae2800/post" />
 
 Qalbatau 부근부터 바람도 끊기고, 도로 상태도 나빠진다.
 
-<ui-lazy-image cfId="a9a66319-f854-4b80-a70d-38b1ccd18400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a9a66319-f854-4b80-a70d-38b1ccd18400/post" />
 
 # 2018년 7월 19일
 
-<ui-lazy-image cfId="6cde485a-7b6b-4139-2684-ae797b8ce000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6cde485a-7b6b-4139-2684-ae797b8ce000/post" />
 
 Qalbatau에서부터는
 
-<ui-lazy-image cfId="1fc5e43e-45ee-4693-da61-07ed0807f500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1fc5e43e-45ee-4693-da61-07ed0807f500/post" />
 
 도로의 상태가 심히 나쁘다.
 
-<ui-lazy-image cfId="4737ec77-c8c8-47cf-6ae3-63fdc9fc1c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4737ec77-c8c8-47cf-6ae3-63fdc9fc1c00/post" />
 
 많은 구간에서
 
-<ui-lazy-image cfId="a1e30024-f42f-4ceb-7410-d1ee0f389b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a1e30024-f42f-4ceb-7410-d1ee0f389b00/post" />
 
 차들이 부서진 아스팔트를 피하기 위해 S자로 운전하거나
 
-<ui-lazy-image cfId="8484fa71-6abf-4b7d-9ce9-4472487d8300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8484fa71-6abf-4b7d-9ce9-4472487d8300/post" />
 
 그냥 아스팔트 도로를 포기하고 갓길로 달린다.
 
-<ui-lazy-image cfId="f4f065cb-97bd-4fa1-a9f0-3f5c5a8f6e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f4f065cb-97bd-4fa1-a9f0-3f5c5a8f6e00/post" />
 
 갓길로 달리는 차는 내 오른쪽으로 지나가게 되는데,
 
-<ui-lazy-image cfId="b8beb9f6-6a3d-4f41-d339-def256a18500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b8beb9f6-6a3d-4f41-d339-def256a18500/post" />
 
 자전거를 타는 입장에서는 그럴 때마다 깜짝 놀란다.
 
-<ui-lazy-image cfId="fbc3b10b-de65-44b7-1bec-7e2501b25e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/fbc3b10b-de65-44b7-1bec-7e2501b25e00/post" />
 
 그리고 나는 엉덩이가 너무 아프다.
 
-<ui-lazy-image cfId="971a3b55-5b52-415e-906b-d621ebb96b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/971a3b55-5b52-415e-906b-d621ebb96b00/post" />
 
 부서진 아스팔트 길에서 오는 진동을 그대로 다 받아내는 내 엉덩이 ㅠㅠ
 
 # 2018년 7월 20일
 
-<ui-lazy-image cfId="68e940a8-14fb-4c62-6669-275565f85000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/68e940a8-14fb-4c62-6669-275565f85000/post" />
 
 도로 중간 중간에 이렇게 휴게소같은 곳이 있다.
 
 아래층에는 식당, 위에는 숙소.
 
-<ui-lazy-image cfId="8444d667-2092-481b-ff85-18518b559600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8444d667-2092-481b-ff85-18518b559600/post" />
 
 아무래도 운전자들을 위한 곳이라 자전거를 타는 입장에서는 하루종일 달려야 겨우 다음 휴게소에 도착할 수 있다.
 
 계속 이렇게 꾸역꾸역 다음 휴게소까지 가서 저녁과 잠을 해결하고 있다.
 
-<ui-lazy-image cfId="67dada8d-e74e-4cd1-637c-391148850b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/67dada8d-e74e-4cd1-637c-391148850b00/post" />
 
 그런데 내일은 그 중 휴게소 간 거리가 가장 먼 구간으로, 200km 정도였나?
 
@@ -90,11 +90,11 @@ Qalbatau에서부터는
 
 # 2018년 7월 21일
 
-<ui-lazy-image cfId="4482e816-9957-4876-eb03-277b0eebca00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4482e816-9957-4876-eb03-277b0eebca00/post" />
 
 날씨가 점점 더워진다.
 
-<ui-lazy-image cfId="74eec984-f7ce-40f1-e0ce-5e953cfb4f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/74eec984-f7ce-40f1-e0ce-5e953cfb4f00/post" />
 
 다행히 중간에 건물이 있었다.
 
@@ -104,7 +104,7 @@ Qalbatau에서부터는
 
 # 2018년 7월 22일
 
-<ui-lazy-image cfId="17babfc4-3c52-4117-2dbd-3e9599406e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/17babfc4-3c52-4117-2dbd-3e9599406e00/post" />
 
 저 건초더미 뒤에서 잤다.
 
@@ -136,21 +136,21 @@ Kabanbay에서 하루 더 쉼.
 
 # 2018년 7월 24일
 
-<ui-lazy-image cfId="3b361c0b-97ac-4be6-bc9a-7c42fb2d8900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3b361c0b-97ac-4be6-bc9a-7c42fb2d8900/post" />
 
 탈디코르간 직전 구간에서는 최근 치안이 좋지 않다는 소식을 접했다.
 
-<ui-lazy-image cfId="a71197a9-d3b8-488f-c807-e8ba8799f500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a71197a9-d3b8-488f-c807-e8ba8799f500/post" />
 
 Sarkand에 있는 모텔에 들어갔다.
 
 모텔 입구에는 수배중인 사람들의 포스터가 붙어 있었다.
 
-<ui-lazy-image cfId="1c004362-8a33-4f90-5c66-f3ffee438c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1c004362-8a33-4f90-5c66-f3ffee438c00/post" />
 
 # 2018년 7월 25일
 
-<ui-lazy-image cfId="1f3a1307-5512-4a25-100c-d2a578c7f400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1f3a1307-5512-4a25-100c-d2a578c7f400/post" />
 
 이젠 버스 정류장의 그늘을 두고 말들과 경쟁을 해야 된다.
 
@@ -172,7 +172,7 @@ Sarkand에 있는 모텔에 들어갔다.
 
 나도 그 차를 얻어타고 알마티로 점프했다.
 
-<ui-lazy-image cfId="b7e779a2-641a-48a6-1d83-fc13ba458d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b7e779a2-641a-48a6-1d83-fc13ba458d00/post" />
 
 우와 오랜만에 고속도로 타니까 신세계네.
 

--- a/src/pages/posts/routes/2018-07-27~2018-08-03.md
+++ b/src/pages/posts/routes/2018-07-27~2018-08-03.md
@@ -12,35 +12,35 @@ countries: [KZ, KG]
 
 할 게 많다.
 
-<ui-lazy-image cfId="c11abe1f-ff76-402c-1b67-2ed100928500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c11abe1f-ff76-402c-1b67-2ed100928500/post" />
 
 일단 이란 비자부터 신청하러 가야지.
 
-<ui-lazy-image cfId="0d8c656c-e3a1-4515-14ef-335eab7ab600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0d8c656c-e3a1-4515-14ef-335eab7ab600/post" />
 
 요즘 투르크메니스탄 비자는 타지키스탄에서 해도 충분하단다.
 
-<ui-lazy-image cfId="9b587866-1816-4e40-7166-247b2ee5cf00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9b587866-1816-4e40-7166-247b2ee5cf00/post" />
 
 내가 알마티에 오기 약 1주 전에 카자흐스탄의 피겨 스케이팅 선수인 데니스 텐이 사망하는 사건이 있었다.
 
-<ui-lazy-image cfId="e47cbc88-5a78-440a-8fe0-a6779934f300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e47cbc88-5a78-440a-8fe0-a6779934f300/post" />
 
 여기가 그 현장 근처인 것 같다.
 
-<ui-lazy-image cfId="6d951b38-8c08-4363-6025-63dbfa6a8a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6d951b38-8c08-4363-6025-63dbfa6a8a00/post" />
 
 많은 사람들이 데니스 텐을 추모하고 있다.
 
-<ui-lazy-image cfId="fc7e8935-a47e-4422-57cd-397b4b637000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/fc7e8935-a47e-4422-57cd-397b4b637000/post" />
 
 Rest in peace.
 
-<ui-lazy-image cfId="2993a6a6-e73d-449a-a2df-36ff9f29a600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2993a6a6-e73d-449a-a2df-36ff9f29a600/post" />
 
 성당보다 더 중요한 게 있다.
 
-<ui-lazy-image cfId="7eb0b629-beed-420c-ee2a-87f6a33f1600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7eb0b629-beed-420c-ee2a-87f6a33f1600/post" />
 
 내 집 마련.
 
@@ -48,19 +48,19 @@ Rest in peace.
 
 # 2018년 8월 28일
 
-<ui-lazy-image cfId="b03884ac-d262-4b83-fbf3-84c5b2171600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b03884ac-d262-4b83-fbf3-84c5b2171600/post" />
 
 자전거 정비를 한다.
 
 앞으로 몇 개월 동안은 알마티만큼 수리를 제대로 받을 수 있는 곳이 없다.
 
-<ui-lazy-image cfId="77db6578-dbd5-4de1-d674-3711f9172200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/77db6578-dbd5-4de1-d674-3711f9172200/post" />
 
 알마티에 있는 매우 괜찮은 바이크샵.
 
 키르기스스탄에서 쓸 비포장 타이어로 구매했다.
 
-<ui-lazy-image cfId="fc3bc00f-0f72-4630-c4ef-2a7c87ae8000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/fc3bc00f-0f72-4630-c4ef-2a7c87ae8000/post" />
 
 쇼핑몰에 가서 햄버거도 먹고
 
@@ -70,29 +70,29 @@ Rest in peace.
 
 드디어
 
-<ui-lazy-image cfId="8afed166-ec9e-411b-875e-1d084a6d6c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8afed166-ec9e-411b-875e-1d084a6d6c00/post" />
 
 텐트를 샀다.
 
 덤으로 멀티스토브도 샀다.
 
-<ui-lazy-image cfId="2a8f281b-6d38-4ac5-094a-9d0bc5864a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2a8f281b-6d38-4ac5-094a-9d0bc5864a00/post" />
 
 호스텔 친구들과 알마티 뒷산에 버스 타고 놀러갔는데
 
-<ui-lazy-image cfId="4e06e3ba-c202-4e57-deb1-e553b4258100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4e06e3ba-c202-4e57-deb1-e553b4258100/post" />
 
 어디더라? 구글맵을 봐도 모르겠네.
 
-<ui-lazy-image cfId="e62d6e30-96c2-4c57-5563-4486e18f3200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e62d6e30-96c2-4c57-5563-4486e18f3200/post" />
 
 내가 이래서 자전거로 여행한다.
 
-<ui-lazy-image cfId="478136ad-dbbd-42de-b907-964d89eb9300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/478136ad-dbbd-42de-b907-964d89eb9300/post" />
 
 내가 직접 간 게 아니면 어딘지 기억을 못한다.
 
-<ui-lazy-image cfId="6c95e64e-403d-46c8-81f2-878824c7bb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6c95e64e-403d-46c8-81f2-878824c7bb00/post" />
 
 모로코까지 육로로 가는 길은 머리속에 다 있다.
 
@@ -102,7 +102,7 @@ Rest in peace.
 
 # 2018년 7월 30일
 
-<ui-lazy-image cfId="073a0f4f-621a-499c-c75e-f7eac6a84300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/073a0f4f-621a-499c-c75e-f7eac6a84300/post" />
 
 판초를 하나 받았다.
 
@@ -116,33 +116,33 @@ Rest in peace.
 
 # 2018년 7월 31일
 
-<ui-lazy-image cfId="7b8f5e93-0415-4414-603d-24da450fc600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7b8f5e93-0415-4414-603d-24da450fc600/post" />
 
 알마티를 떠난다.
 
 놀고 먹는건 비슈케크 가서 해야지.
 
-<ui-lazy-image cfId="4d2a7f98-d021-4d68-b205-13cb0c603200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4d2a7f98-d021-4d68-b205-13cb0c603200/post" />
 
 알마티같은 대도시는 빠져나오는게 빡세다.
 
 아휴.. 자전거로 고속도로도 타야되고 정말...
 
-<ui-lazy-image cfId="dff69acb-377b-4ece-3ebe-3870cd1d2d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/dff69acb-377b-4ece-3ebe-3870cd1d2d00/post" />
 
 캠핑 어디서 하지...
 
 # 2018년 8월 01일
 
-<ui-lazy-image cfId="4a3f1861-8731-4968-93dc-d6fa068adf00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4a3f1861-8731-4968-93dc-d6fa068adf00/post" />
 
 굿모닝
 
-<ui-lazy-image cfId="f5ef0de5-872e-4d49-f893-ac5b57a19000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f5ef0de5-872e-4d49-f893-ac5b57a19000/post" />
 
 해가 지고 나서 텐트를 쳤더니 플라이를 뒤집어서 쳤다. ㅎㅎㅎ
 
-<ui-lazy-image cfId="3101a7e3-97ca-4a64-c4e6-fb9753970100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3101a7e3-97ca-4a64-c4e6-fb9753970100/post" />
 
 사진으로는 잘 보이지 않지만 저 멀리 눈 쌓인 산맥이 보이기 시작한다.
 
@@ -156,17 +156,17 @@ Rest in peace.
 
 비슈케크 구경.
 
-<ui-lazy-image cfId="8fa037c4-c9af-42c0-20ba-6f4067fe8700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8fa037c4-c9af-42c0-20ba-6f4067fe8700/post" />
 
-<ui-lazy-image cfId="2d7ea61b-0119-4751-27b0-30a96376e500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2d7ea61b-0119-4751-27b0-30a96376e500/post" />
 
 # 2018년 8월 03일
 
-<ui-lazy-image cfId="cb24f241-a129-4e90-acbd-3c4743b8fa00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/cb24f241-a129-4e90-acbd-3c4743b8fa00/post" />
 
 Simon과 Dominik을 다시 만났다!
 
-<ui-lazy-image cfId="42c0b119-a470-49ef-27e6-415ff7c0fd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/42c0b119-a470-49ef-27e6-415ff7c0fd00/post" />
 
 이탈리아에서 온 [발렌티나](https://www.instagram.com/valentinaonwheels/)도 만났다.
 

--- a/src/pages/posts/routes/2018-08-04~2018-08-09.md
+++ b/src/pages/posts/routes/2018-08-04~2018-08-09.md
@@ -10,214 +10,214 @@ countries: [KG]
 
 우와 늦을 뻔 했다.
 
-<ui-lazy-image cfId="e8210770-aff3-4330-94ff-9aa84a94ec00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e8210770-aff3-4330-94ff-9aa84a94ec00/post" />
 
 생각 외로 사람들이 많다.
 
-<ui-lazy-image cfId="26926610-39bc-41d6-efc2-0f97b17d9500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/26926610-39bc-41d6-efc2-0f97b17d9500/post" />
 
 이 열차는 하계에만 운행하는 열차로,
 
 비슈케크에서 이식쿨에 있는 Balykchy까지 운행하는 열차다.
 
-<ui-lazy-image cfId="5fb22c41-2df9-41d5-40b3-7b57ab9e6d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5fb22c41-2df9-41d5-40b3-7b57ab9e6d00/post" />
 
 자전거를 따로 넣을 수 있는 공간은 없다.
 
-<ui-lazy-image cfId="6eab249f-a343-4e36-8b18-ab69d27c8100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6eab249f-a343-4e36-8b18-ab69d27c8100/post" />
 
 그래서 기차 맨 뒤 흡연 공간에 자리잡은 내 자전거 ㅋㅋㅋ
 
-<ui-lazy-image cfId="1de4b5dd-2833-4592-3dc5-9d4f96397300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1de4b5dd-2833-4592-3dc5-9d4f96397300/post" />
 
 옆 좌석엔 수학 교수님과 손주들이 자리잡았다.
 
-<ui-lazy-image cfId="787190c6-444b-414c-3b7c-5ce0c7ff2500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/787190c6-444b-414c-3b7c-5ce0c7ff2500/post" />
 
 아이들이 나한테 뭔가 물어보는데 알아듣지를 못했다.
 
 구글 번역기를 돌려서 보여줬는데, 방탄복이 나오는 거였다.
 
-<ui-lazy-image cfId="9399419a-5a14-4ff1-25f7-75250ffc2c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9399419a-5a14-4ff1-25f7-75250ffc2c00/post" />
 
 음?? 뭐지???
 
-<ui-lazy-image cfId="8bc4fc4c-168f-48d9-22bb-531940291000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8bc4fc4c-168f-48d9-22bb-531940291000/post" />
 
 BTS를 말하는 거였다. ㅋㅋㅋㅋㅋ
 
-<ui-lazy-image cfId="1ea1c393-d40d-4035-915c-48bb1e5c6400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1ea1c393-d40d-4035-915c-48bb1e5c6400/post" />
 
 Balykchy에 도착.
 
-<ui-lazy-image cfId="28bd6e23-39e3-4d7d-01e5-fab6447ba000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/28bd6e23-39e3-4d7d-01e5-fab6447ba000/post" />
 
 다시 달려볼까
 
-<ui-lazy-image cfId="3099cdc1-4168-4b42-52fd-10b524bdc100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3099cdc1-4168-4b42-52fd-10b524bdc100/post" />
 
 이식쿨(쿨이 호수라는 의미)로 들어가는 길이 있어서 호수 구경하러 들어갔다.
 
-<ui-lazy-image cfId="1daa46a0-b46e-4924-a3be-06769bb9b100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1daa46a0-b46e-4924-a3be-06769bb9b100/post" />
 
 나들이를 나온 가족들이 많다.
 
-<ui-lazy-image cfId="5f575bf1-ad39-4851-505e-80db8099d100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5f575bf1-ad39-4851-505e-80db8099d100/post" />
 
 길가에서는 이렇게 과일을 팔기도 한다.
 
-<ui-lazy-image cfId="ec9c5328-5abb-4ee3-6607-675e1cc32600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ec9c5328-5abb-4ee3-6607-675e1cc32600/post" />
 
 엄마가 자리를 비운 사이 일을 거드는 아이들.
 
 과일을 좀 샀다.
 
-<ui-lazy-image cfId="567fa8fc-b3cb-428c-b7f0-3cdc90ecb300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/567fa8fc-b3cb-428c-b7f0-3cdc90ecb300/post" />
 
 오늘밤은 캠핑할 곳을 정해놨는데
 
-<ui-lazy-image cfId="29ffa1ec-b739-461d-88de-a95102b05c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/29ffa1ec-b739-461d-88de-a95102b05c00/post" />
 
 아, 길을 잘못 들었다.
 
-<ui-lazy-image cfId="252b2679-8e08-4f5c-3d51-d9e50c82e800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/252b2679-8e08-4f5c-3d51-d9e50c82e800/post" />
 
 돌아나가지 않고 그냥 가본다.
 
-<ui-lazy-image cfId="e779bca1-9924-418e-c998-1e60c2695600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e779bca1-9924-418e-c998-1e60c2695600/post" />
 
-<ui-lazy-image cfId="a21dff8b-10b0-4adf-78dc-af340e1bb000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a21dff8b-10b0-4adf-78dc-af340e1bb000/post" />
 
 # 2018-08-05
 
-<ui-lazy-image cfId="659709d5-7e13-4387-96be-2d4e66597000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/659709d5-7e13-4387-96be-2d4e66597000/post" />
 
 굿모닝
 
-<ui-lazy-image cfId="2c5fd741-93de-42bc-870f-857d498dff00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2c5fd741-93de-42bc-870f-857d498dff00/post" />
 
 결국 원래 캠핑하려고 했던 곳까지 못 가서 텐트를 쳤다.
 
-<ui-lazy-image cfId="13e5a1af-8b18-4994-6ef8-8688e22bc700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/13e5a1af-8b18-4994-6ef8-8688e22bc700/post" />
 
 여기는 이식쿨 옆에 있는 작은 호수인데,
 
 여기 물이(정확히는 진흙이) 몸에 좋다고 해서 몸 담그러 많이 온다.
 
-<ui-lazy-image cfId="4b61af20-eb1a-4cb5-f85f-c1dcedff1600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4b61af20-eb1a-4cb5-f85f-c1dcedff1600/post" />
 
 자전거는 세워두고 나도 들어가봤다.
 
-<ui-lazy-image cfId="b9aa255e-cf51-4a4c-a32e-f296fd65e900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b9aa255e-cf51-4a4c-a32e-f296fd65e900/post" />
 
 정말 들어가진 않고 구경만...
 
-<ui-lazy-image cfId="3db82a25-a3b3-4152-6b4b-e2c5c2ccac00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3db82a25-a3b3-4152-6b4b-e2c5c2ccac00/post" />
 
 사진 찍어달라는 요청도 받고
 
-<ui-lazy-image cfId="8feb1481-a494-4b21-05af-4abc662c1f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8feb1481-a494-4b21-05af-4abc662c1f00/post" />
 
 같이 셀카도 찍었다.
 
-<ui-lazy-image cfId="5b16a472-84a2-4acc-bada-979fbfdfcb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5b16a472-84a2-4acc-bada-979fbfdfcb00/post" />
 
 우옹
 
-<ui-lazy-image cfId="492f08e8-aa20-487e-3b62-863d0f716d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/492f08e8-aa20-487e-3b62-863d0f716d00/post" />
 
 내가 원래 캠핑하려던 곳.
 
-<ui-lazy-image cfId="963eae32-bbca-437c-4e31-615cca238b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/963eae32-bbca-437c-4e31-615cca238b00/post" />
 
 너무 좋다...
 
 왜 길을 잘못 들어서 ㅠㅠ
 
-<ui-lazy-image cfId="a0036032-9419-499f-13e7-d5e09f807100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a0036032-9419-499f-13e7-d5e09f807100/post" />
 
-<ui-lazy-image cfId="170facc5-4dd1-45c7-275d-c437187cc700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/170facc5-4dd1-45c7-275d-c437187cc700/post" />
 
 이식쿨은 바다만큼은 아니지만 염분이 있다.
 
-<ui-lazy-image cfId="a34c4e1c-17fa-4aa8-4c8f-6504eb1c4300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a34c4e1c-17fa-4aa8-4c8f-6504eb1c4300/post" />
 
 사실이다.
 
-<ui-lazy-image cfId="3a32304e-821f-4284-1592-a03fcf248c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3a32304e-821f-4284-1592-a03fcf248c00/post" />
 
 내가 맛을 봤다.
 
-<ui-lazy-image cfId="b8c0cda1-2d4d-4fcc-f5de-1a900bfc3500" />
-<ui-lazy-image cfId="e40f06e1-1add-4e82-32e8-b7f1909ab700" />
-<ui-lazy-image cfId="0c630e59-3d7e-4842-9cb4-92af57630e00" />
-<ui-lazy-image cfId="b91836a6-2ecb-4575-39e5-062b0867a800" />
-<ui-lazy-image cfId="6a1da556-cd75-45b5-ca73-4b1a058a0700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b8c0cda1-2d4d-4fcc-f5de-1a900bfc3500/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e40f06e1-1add-4e82-32e8-b7f1909ab700/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0c630e59-3d7e-4842-9cb4-92af57630e00/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b91836a6-2ecb-4575-39e5-062b0867a800/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6a1da556-cd75-45b5-ca73-4b1a058a0700/post" />
 
 키르기스스탄에는
 
-<ui-lazy-image cfId="5fad7f0c-1192-4d31-373c-2e4b8149c800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5fad7f0c-1192-4d31-373c-2e4b8149c800/post" />
 
 키르기스 콜라가 있다.
 
-<ui-lazy-image cfId="0dbb4d8a-3245-4df3-195c-b1407771fb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0dbb4d8a-3245-4df3-195c-b1407771fb00/post" />
 
 포장 도로로 다시 돌아왔는데
 
-<ui-lazy-image cfId="3a0255df-e581-422a-028f-7a6350168900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3a0255df-e581-422a-028f-7a6350168900/post" />
 
 금새 지루해져서
 
-<ui-lazy-image cfId="48660ba5-6b10-4ba8-ef8a-58fee2824700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/48660ba5-6b10-4ba8-ef8a-58fee2824700/post" />
 
 또 다른 길로 가본다.
 
-<ui-lazy-image cfId="7c954e3e-e008-4810-3360-d5d4b9593300" />
-<ui-lazy-image cfId="ebd21877-806c-42d2-2e88-c167ca38eb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7c954e3e-e008-4810-3360-d5d4b9593300/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ebd21877-806c-42d2-2e88-c167ca38eb00/post" />
 
-<ui-lazy-image cfId="2dd47c6d-a6c8-4675-a57a-e89374a6f000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2dd47c6d-a6c8-4675-a57a-e89374a6f000/post" />
 
 # 2018-08-06
 
-<ui-lazy-image cfId="52231e48-20cb-4eb6-a66c-fb8a77c55700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/52231e48-20cb-4eb6-a66c-fb8a77c55700/post" />
 
 게으름 피우다가 느릿느릿 일어남.
 
-<ui-lazy-image cfId="2d7061c1-0f71-4820-edda-3526abd6a200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2d7061c1-0f71-4820-edda-3526abd6a200/post" />
 
 키르기스스탄의 시골길
 
-<ui-lazy-image cfId="209bd428-d449-4d8a-364c-013a20d3c400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/209bd428-d449-4d8a-364c-013a20d3c400/post" />
 
 사람도 없고 좋구나
 
-<ui-lazy-image cfId="871569e1-55cf-403b-0cc6-c99db85d3f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/871569e1-55cf-403b-0cc6-c99db85d3f00/post" />
 
-<ui-lazy-image cfId="3012a0c6-75c7-4457-dbf1-c0111d910600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3012a0c6-75c7-4457-dbf1-c0111d910600/post" />
 
 이 길은 다시 이식쿨로 돌아가는데
 
-<ui-lazy-image cfId="9adbfe15-b396-4ded-72b7-d97ce94a7f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9adbfe15-b396-4ded-72b7-d97ce94a7f00/post" />
 
 갑자기 이런 계곡으로
 
-<ui-lazy-image cfId="8ffdbc20-bc8f-4c81-8584-bc310b7cf800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8ffdbc20-bc8f-4c81-8584-bc310b7cf800/post" />
 
 빠져나간다.
 
-<ui-lazy-image cfId="0d29371f-afe5-49b9-daec-611c7ec20500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0d29371f-afe5-49b9-daec-611c7ec20500/post" />
 
 오 좀 멋있..
 
-<ui-lazy-image cfId="e15c05a7-964c-4138-2d4e-98dbbf1e6900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e15c05a7-964c-4138-2d4e-98dbbf1e6900/post" />
 
 으려 했는데 끝났다. ㅎㅎㅎ
 
-<ui-lazy-image cfId="11179064-60b5-43e0-db0b-ecb8d030f400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/11179064-60b5-43e0-db0b-ecb8d030f400/post" />
 
 점저도 먹고 계속 동쪽으로 달리는데 사람들이 점점 많아진다.
 
-<ui-lazy-image cfId="22447ed5-ef04-4694-b35f-c08253abcf00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/22447ed5-ef04-4694-b35f-c08253abcf00/post" />
 
 아마 키르기스스탄 휴가철이었던 것 같다.
 
@@ -225,7 +225,7 @@ Balykchy에 도착.
 
 무슨 해운대 같이 사람들이 많은 곳도 있었다.
 
-<ui-lazy-image cfId="e13c2c95-6f3f-488b-e310-2985c0881a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e13c2c95-6f3f-488b-e310-2985c0881a00/post" />
 
 Kyzyl Suu에서 애들한테 물어서 카페에 들어왔다.
 
@@ -233,13 +233,13 @@ Kyzyl Suu에서 애들한테 물어서 카페에 들어왔다.
 
 커피가 아니라 주로 식사를 하고, 규모가 조금 크면 이렇게 잘 곳이 있다.
 
-<ui-lazy-image cfId="0ba910c0-0324-4d32-0a9f-225080bbcb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0ba910c0-0324-4d32-0a9f-225080bbcb00/post" />
 
 카페 수사르.
 
 # 2018-08-07
 
-<ui-lazy-image cfId="f5ec55f6-628d-422a-eb7b-c7ae61204700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f5ec55f6-628d-422a-eb7b-c7ae61204700/post" />
 
 일단 카라콜로 좀 쉬러 가고 있는데, 중간에 관광명소가 있다.
 
@@ -247,15 +247,15 @@ Kyzyl Suu에서 애들한테 물어서 카페에 들어왔다.
 
 여기까지 왔는데.
 
-<ui-lazy-image cfId="cbadeb50-cb41-4528-06a8-236ae0377a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/cbadeb50-cb41-4528-06a8-236ae0377a00/post" />
 
 ....
 
-<ui-lazy-image cfId="60572ddc-6522-4b03-7646-e2d9bd0c9b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/60572ddc-6522-4b03-7646-e2d9bd0c9b00/post" />
 
 무감흥.
 
-<ui-lazy-image cfId="2f7b74dd-3dbf-4338-3d74-aaafdf31f600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2f7b74dd-3dbf-4338-3d74-aaafdf31f600/post" />
 
 ㅃㅃ
 
@@ -271,7 +271,7 @@ Kyzyl Suu에서 애들한테 물어서 카페에 들어왔다.
 
 그걸 자전거에 실어서 여기까지 왔다.
 
-<ui-lazy-image cfId="f4f9380c-c6fd-4be0-d6b7-c7ca72314100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f4f9380c-c6fd-4be0-d6b7-c7ca72314100/post" />
 
 카라콜 시장에 가서 자전거 가게를 찾아갔다.
 
@@ -283,11 +283,11 @@ Kyzyl Suu에서 애들한테 물어서 카페에 들어왔다.
 
 그 치수가 다른 타이어를 드리고 가격을 좀 깎았다.
 
-<ui-lazy-image cfId="71703a59-1b76-4144-cab4-cbb7aed3b100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/71703a59-1b76-4144-cab4-cbb7aed3b100/post" />
 
 나무로 지은 그리스 정교회 성당이다.
 
-<ui-lazy-image cfId="75589709-f9e8-4819-8006-eb66d6f32700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/75589709-f9e8-4819-8006-eb66d6f32700/post" />
 
 좀 색다른게 괜찮은데?
 

--- a/src/pages/posts/routes/2018-08-10~2018-08-18.md
+++ b/src/pages/posts/routes/2018-08-10~2018-08-18.md
@@ -8,111 +8,111 @@ countries: [KG]
 
 # 2018년 8월 10일
 
-<ui-lazy-image cfId="407eee5e-bd08-4fc8-b67f-e0e51e7ca800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/407eee5e-bd08-4fc8-b67f-e0e51e7ca800/post" />
 
 오늘부터 [Tian Shan Traverse, Kyrgyzstan](https://bikepacking.com/routes/tian-shan-traverse-kyrgyzstan/)를 시작한다.
 
-<ui-lazy-image cfId="b01a76ca-3add-489c-669c-0a3a110b0000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b01a76ca-3add-489c-669c-0a3a110b0000/post" />
 
 이미 지나쳤던 kyzil suu까지 돌아가야 하기에 택시를 이용했다.
 
-<ui-lazy-image cfId="fc126f75-9f28-46cd-1c6f-d762256f1900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/fc126f75-9f28-46cd-1c6f-d762256f1900/post" />
 
 마침 같은 곳으로 가는 친구들이 있어서 함께 타고 왔다.
 
 하지만 각자 루트가 달라서 금방 헤어졌다.
 
-<ui-lazy-image cfId="b48f3fff-c4eb-43ed-1946-451c2dcab400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b48f3fff-c4eb-43ed-1946-451c2dcab400/post" />
 
 시작은 쉽고 완만한 경사가 이어진다.
 
-<ui-lazy-image cfId="3261c307-c891-4f88-9490-fd4097d9ed00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3261c307-c891-4f88-9490-fd4097d9ed00/post" />
 
-<ui-lazy-image cfId="13c74903-4318-4b71-5fa6-a3cdc1d6ff00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/13c74903-4318-4b71-5fa6-a3cdc1d6ff00/post" />
 
-<ui-lazy-image cfId="1163700b-d006-40b2-221c-79391940fe00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1163700b-d006-40b2-221c-79391940fe00/post" />
 
 나무 그늘 아래에서의 점심.
 
-<ui-lazy-image cfId="37b036d9-9e02-4832-4805-ee34cf687600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/37b036d9-9e02-4832-4805-ee34cf687600/post" />
 
-<ui-lazy-image cfId="48ec5940-7de7-44c6-588b-d9c9bb899800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/48ec5940-7de7-44c6-588b-d9c9bb899800/post" />
 
-<ui-lazy-image cfId="1670a23b-f2ad-4422-146c-59e680d0f600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1670a23b-f2ad-4422-146c-59e680d0f600/post" />
 
-<ui-lazy-image cfId="12390d5a-7422-4fab-9633-a2680b6e8300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/12390d5a-7422-4fab-9633-a2680b6e8300/post" />
 
-<ui-lazy-image cfId="16c3731e-f4c9-4935-4b03-07e1ee28da00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/16c3731e-f4c9-4935-4b03-07e1ee28da00/post" />
 
-<ui-lazy-image cfId="51a149f6-d395-40f3-a8ca-6597b1cdd100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/51a149f6-d395-40f3-a8ca-6597b1cdd100/post" />
 
-<ui-lazy-image cfId="5993550d-313c-4803-8e57-ccc79a765500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5993550d-313c-4803-8e57-ccc79a765500/post" />
 
-<ui-lazy-image cfId="496b799c-ea16-4470-cc2e-8c708bbc1200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/496b799c-ea16-4470-cc2e-8c708bbc1200/post" />
 
 의외로 깊기 때문에 나무 다리를 이용하는 것이 좋다.
 
-<ui-lazy-image cfId="04415e00-c004-4842-6b10-e0d1e30a1300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/04415e00-c004-4842-6b10-e0d1e30a1300/post" />
 
 이곳을 건너서 나오는 평탄한 곳에서 캠핑을 했다.
 
-<ui-lazy-image cfId="19614bac-8e23-4d2f-329c-4ea3bba3f200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/19614bac-8e23-4d2f-329c-4ea3bba3f200/post" />
 
 # 2018년 8월 11일
 
-<ui-lazy-image cfId="b9138524-3b1c-472d-76eb-3b032c784d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b9138524-3b1c-472d-76eb-3b032c784d00/post" />
 
 아침은 라면을 먹었다.
 
-<ui-lazy-image cfId="4bbb1d17-79cf-4456-08e3-21a8b330d000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4bbb1d17-79cf-4456-08e3-21a8b330d000/post" />
 
-<ui-lazy-image cfId="3091f3d8-e413-4f21-0b81-a9c3c4d15400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3091f3d8-e413-4f21-0b81-a9c3c4d15400/post" />
 
 곧바로 급경사가 시작됐다.
 
 내 Disk Trucker로 올라가기엔 좀 무리가 있어서 바로 끌바가 시작됐다.
 
-<ui-lazy-image cfId="6f1f225f-d63c-41d3-2ced-a23802d05100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6f1f225f-d63c-41d3-2ced-a23802d05100/post" />
 
-<ui-lazy-image cfId="63f53060-b32d-4a20-349e-dde50c4b5c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/63f53060-b32d-4a20-349e-dde50c4b5c00/post" />
 
-<ui-lazy-image cfId="428df370-aaff-4ccc-4258-5fe061505300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/428df370-aaff-4ccc-4258-5fe061505300/post" />
 
-<ui-lazy-image cfId="9e0d13b5-9fa9-4bb0-d34e-11f468cd5200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9e0d13b5-9fa9-4bb0-d34e-11f468cd5200/post" />
 
-<ui-lazy-image cfId="b26ef1f3-b6de-47fa-70f4-cfd4f7492600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b26ef1f3-b6de-47fa-70f4-cfd4f7492600/post" />
 
-<ui-lazy-image cfId="5ab89347-1675-4ea4-2c9b-9be45d002600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5ab89347-1675-4ea4-2c9b-9be45d002600/post" />
 
 첫 번째 고개인 Dzhuku Pass가 보인다.
 
-<ui-lazy-image cfId="52258b45-1c22-4a4f-5457-d076fe18c200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/52258b45-1c22-4a4f-5457-d076fe18c200/post" />
 
 카메라 설정을 잘못해서 어둡게 나왔넹.
 
-<ui-lazy-image cfId="6a020a4e-a1a4-4455-3649-3fc943458900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6a020a4e-a1a4-4455-3649-3fc943458900/post" />
 
 그냥 끌바로는 안 되고 자전거를 거의 들어서 가야 한다.
 
-<ui-lazy-image cfId="c416d28d-da80-4408-6e8e-95a56b954300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c416d28d-da80-4408-6e8e-95a56b954300/post" />
 
 예전에 네팔에서 경험한 바로는 나는 고도 3,000m ~ 3,500m에서부터 고산증세가 시작된다.
 
-<ui-lazy-image cfId="c808735a-cda9-4d84-33c7-887f358ef100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c808735a-cda9-4d84-33c7-887f358ef100/post" />
 
 아이고 산소가 모자라.
 
 슬슬 고산 증세도 오는 것 같고.
 
-<ui-lazy-image cfId="b37e6855-164f-42ce-d779-b84e3259d100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b37e6855-164f-42ce-d779-b84e3259d100/post" />
 
 Dzhuku Pass 정상에 도착하면 내리막이 아니라 고원이 펼쳐진다.
 
-<ui-lazy-image cfId="3d1b6870-208a-4d76-b874-3edca1ebd200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3d1b6870-208a-4d76-b874-3edca1ebd200/post" />
 
 나처럼 26인치 타이어면 평지여도 끌바를 많이 해야 된다.
 
-<ui-lazy-image cfId="1eb4678a-591f-4c7e-e092-1bfa7639fe00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1eb4678a-591f-4c7e-e092-1bfa7639fe00/post" />
 
 도하를 1번 이상 하게 된다.
 
@@ -120,43 +120,43 @@ Dzhuku Pass 정상에 도착하면 내리막이 아니라 고원이 펼쳐진다
 
 2번째 도하에서는 깊이가 허벅지 중간 정도였다.
 
-<ui-lazy-image cfId="97d517bc-f2a4-4e0d-6c63-50fddb592e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/97d517bc-f2a4-4e0d-6c63-50fddb592e00/post" />
 
 강바닥은 진흙이라 샌들을 발에 단단히 고정시키는걸 추천한다.
 
 그리고 U자형으로 강바닥이 파여있기 때문에 다시 땅으로 자전거를 밀어 올릴 때 에로사항이 있을 수 있다.
 
-<ui-lazy-image cfId="818282ff-724e-409c-3f12-972a10878300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/818282ff-724e-409c-3f12-972a10878300/post" />
 
 만약 Dzhuku Pass에서의 무식한 끌바를 피하고 싶다면 A364 도로를 타고 오면 된다.
 
-<ui-lazy-image cfId="0a1c4903-27c1-4845-7b2d-a424aee62000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0a1c4903-27c1-4845-7b2d-a424aee62000/post" />
 
 하지만 바이크패킹에 이런 끌바가 없으면 아쉽긴 하다.
 
 # 2018년 8월 12일
 
-<ui-lazy-image cfId="9d4b13ac-e051-4a6f-6421-d14922b87900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9d4b13ac-e051-4a6f-6421-d14922b87900/post" />
 
 새벽부터 비가 내리기 시작하더니
 
-<ui-lazy-image cfId="b9681e82-6c21-4917-e0d4-743823328a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b9681e82-6c21-4917-e0d4-743823328a00/post" />
 
 눈으로 바꼈다.
 
-<ui-lazy-image cfId="0dc61ba0-3e50-4cce-8c3f-1ae2137d7400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0dc61ba0-3e50-4cce-8c3f-1ae2137d7400/post" />
 
 8월에도 이런 날씨와 마주칠 수 있다.
 
-<ui-lazy-image cfId="b5e78bb3-7087-4bd6-41d8-ecf610fac400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b5e78bb3-7087-4bd6-41d8-ecf610fac400/post" />
 
 오 밝아진다.
 
-<ui-lazy-image cfId="6d529dce-bbde-459f-4e34-763e6bebd500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6d529dce-bbde-459f-4e34-763e6bebd500/post" />
 
 그래도 8월이라 눈은 금방 녹았다.
 
-<ui-lazy-image cfId="c96cdae4-0379-4fdd-1f39-fe20862cb900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c96cdae4-0379-4fdd-1f39-fe20862cb900/post" />
 
 이제 날씨가 풀린 줄 알고 출발했다.
 
@@ -164,7 +164,7 @@ Dzhuku Pass 정상에 도착하면 내리막이 아니라 고원이 펼쳐진다
 
 그런데 서쪽에서 번개를 동반한 먹구름이 몰려온다.
 
-<ui-lazy-image cfId="26fc878a-710b-48c0-32f5-c035c0cf4a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/26fc878a-710b-48c0-32f5-c035c0cf4a00/post" />
 
 2시간 만에 다시 텐트를 쳤다.
 
@@ -176,45 +176,45 @@ Dzhuku Pass 정상에 도착하면 내리막이 아니라 고원이 펼쳐진다
 
 # 2018년 8월 13일
 
-<ui-lazy-image cfId="7d94da64-b98a-466e-1d63-9a50b4120500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7d94da64-b98a-466e-1d63-9a50b4120500/post" />
 
 아, 숨 차.
 
-<ui-lazy-image cfId="2aea6626-cc12-4573-c815-e56f13df2d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2aea6626-cc12-4573-c815-e56f13df2d00/post" />
 
 산소가 모자라다.
 
 빨리 고도를 내리고 싶다.
 
-<ui-lazy-image cfId="bf7f76de-a2dd-43c9-b83c-03ebf8ab5700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bf7f76de-a2dd-43c9-b83c-03ebf8ab5700/post" />
 
 어제 내린 비로 길은 진흙밭이 돼 있었다.
 
-<ui-lazy-image cfId="9f713c2c-5f47-4d43-df01-1af181320400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9f713c2c-5f47-4d43-df01-1af181320400/post" />
 
 자전거의 무게가 증가하고, 바퀴가 잘 돌아가지 않는다.
 
-<ui-lazy-image cfId="4390bdfa-c25d-4813-bb56-ab6f8745bd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4390bdfa-c25d-4813-bb56-ab6f8745bd00/post" />
 
 가다가 양을 몰고 있는 할아버지를 만났다.
 
 역시나 멋들어지게 말에 타고 계신다.
 
-<ui-lazy-image cfId="ff48906e-01b1-495b-32bb-620ea133cc00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ff48906e-01b1-495b-32bb-620ea133cc00/post" />
 
 "난 키르기스(사람)이다. 그대는 어디서 왔는굥?"
 
 내가 알아들은 바로는 이랬다.
 
-<ui-lazy-image cfId="cf39fcf8-d8cc-4152-a7bf-dab2da464400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/cf39fcf8-d8cc-4152-a7bf-dab2da464400/post" />
 
 이 여행을 통틀어 가장 멋진 인사말이었는데,
 
-<ui-lazy-image cfId="1b5e6508-fb26-4f75-2efc-8635125afb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1b5e6508-fb26-4f75-2efc-8635125afb00/post" />
 
 왜냐하면 자기소개로 인사를 시작하는 분은 이분이 처음이자 마지막이었기 때문이다.
 
-<ui-lazy-image cfId="4d875c7d-d4d7-4a55-987d-523d495ea000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4d875c7d-d4d7-4a55-987d-523d495ea000/post" />
 
 내 게르 가서 차나 한 잔 하고 갈래? 하시는 걸 공손하게 거절했다.
 
@@ -222,59 +222,59 @@ Dzhuku Pass 정상에 도착하면 내리막이 아니라 고원이 펼쳐진다
 
 그렇다고 하니 허허 웃으면서 조금만 더 가면 내려갈 수 있다고 했다.
 
-<ui-lazy-image cfId="1037dc53-f5fd-4cac-99ab-4c0a48933900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1037dc53-f5fd-4cac-99ab-4c0a48933900/post" />
 
 Arabel Pass.
 
 이제부터 내리막이다.
 
-<ui-lazy-image cfId="c01b0a66-1493-452a-f715-664cb1ef3c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c01b0a66-1493-452a-f715-664cb1ef3c00/post" />
 
-<ui-lazy-image cfId="85a79e2b-795d-4831-4299-158d9e7bcb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/85a79e2b-795d-4831-4299-158d9e7bcb00/post" />
 
-<ui-lazy-image cfId="bde4af3b-8d97-478f-440e-3de1cccead00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bde4af3b-8d97-478f-440e-3de1cccead00/post" />
 
 한바탕 내려왔더니 좀 살 것 같네.
 
-<ui-lazy-image cfId="615370d4-cbd4-4f2b-8c1e-7b40bff93100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/615370d4-cbd4-4f2b-8c1e-7b40bff93100/post" />
 
 잠시 멈춰서 강에서 물을 정수해서 물통을 채웠다.
 
 이 루트에서는 정수기를 가져오는 것이 여러모로 이롭다.
 
-<ui-lazy-image cfId="25067a41-8114-49b6-2a2d-f0d56d5a2400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/25067a41-8114-49b6-2a2d-f0d56d5a2400/post" />
 
 그래프 상으로는 내리막이지만 그런 완만한 내리막은 사실 거의 체감이 되지 않는다.
 
-<ui-lazy-image cfId="b61f03be-d7ab-4586-bf51-ffb84ae26300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b61f03be-d7ab-4586-bf51-ffb84ae26300/post" />
 
-<ui-lazy-image cfId="38a00603-8dd3-4c06-335f-264d9ee62500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/38a00603-8dd3-4c06-335f-264d9ee62500/post" />
 
-<ui-lazy-image cfId="4fc3d7c9-5326-4e24-8c98-9375b769e700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4fc3d7c9-5326-4e24-8c98-9375b769e700/post" />
 
 자전거를 본 적이 드문 말들은 자전거를 굉장히 경계한다.
 
-<ui-lazy-image cfId="4adc692a-522e-46ca-7a97-964aa7663f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4adc692a-522e-46ca-7a97-964aa7663f00/post" />
 
 원래 내 앞에 있던 무리인데 내가 다가가자 망아지를 뒤로 빼면서 흩어지더니 내 뒤로 헤쳐모여를 시전했다.
 
-<ui-lazy-image cfId="aa9f70c1-d73f-4d65-da64-0c62d0313a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/aa9f70c1-d73f-4d65-da64-0c62d0313a00/post" />
 
 뭔가 이상한 느낌이 들어서 뒤를 돌아봤더니 나를 계속 쫓아오고 있었다.
 
 망아지들은 맨 뒤로 빼서 보호하고 있다.
 
-<ui-lazy-image cfId="23907e32-2178-4e9b-5ad5-916bb7ffc300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/23907e32-2178-4e9b-5ad5-916bb7ffc300/post" />
 
 도중에 나타난 게르에서 빵을 좀 샀다.
 
 그런데 게르에 들어와서 좀 더 먹고 가라고 하신다.
 
-<ui-lazy-image cfId="2162a0f1-9c81-408a-5d3f-fe17e8f52700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2162a0f1-9c81-408a-5d3f-fe17e8f52700/post" />
 
 마시쪙...
 
-<ui-lazy-image cfId="86c4df5d-ff15-4862-be8a-27f1382bf500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/86c4df5d-ff15-4862-be8a-27f1382bf500/post" />
 
 한 게르에서 잠깐 들렀다 가라고 했다.
 
@@ -284,29 +284,29 @@ Arabel Pass.
 
 방금 만든 버터는 너무 맛있었다.
 
-<ui-lazy-image cfId="bc17950f-d54f-4770-336e-4367d2681b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bc17950f-d54f-4770-336e-4367d2681b00/post" />
 
 아이들이 착하고 너무 이쁨.
 
-<ui-lazy-image cfId="73a47197-bbd4-434f-e7b2-3d728045e300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/73a47197-bbd4-434f-e7b2-3d728045e300/post" />
 
-<ui-lazy-image cfId="430fbdd3-5faa-41dc-c834-10ccd965a900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/430fbdd3-5faa-41dc-c834-10ccd965a900/post" />
 
-<ui-lazy-image cfId="89b5c6e3-a6ed-4319-3833-0c067b350800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/89b5c6e3-a6ed-4319-3833-0c067b350800/post" />
 
 처음으로 밤하늘을 찍어봤다.
 
-<ui-lazy-image cfId="72cead4f-a388-412b-ec07-41b091270d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/72cead4f-a388-412b-ec07-41b091270d00/post" />
 
 이게 아닌뎅.
 
-<ui-lazy-image cfId="585e426a-aa67-4637-3cc3-86a4b27af900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/585e426a-aa67-4637-3cc3-86a4b27af900/post" />
 
 내 사진기로는 요정도?
 
 # 2018년 8월 14일
 
-<ui-lazy-image cfId="66889e5e-c420-43a5-a837-cb49182cbc00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/66889e5e-c420-43a5-a837-cb49182cbc00/post" />
 
 펑크가 났던 타이어를 버리지 않고 뭔가 묶어둘 요량으로 가지고 있었었다.
 
@@ -316,7 +316,7 @@ Arabel Pass.
 
 나는 그럼요! 하고 기꺼이 드렸다.
 
-<ui-lazy-image cfId="7cf3b458-b295-49b4-a84d-a79b3051d700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7cf3b458-b295-49b4-a84d-a79b3051d700/post" />
 
 아이가 내 가방에 꽂아두었던 스니커즈 껍질을 슬쩍 만져보더니 실망한 눈빛을 짓는다.
 
@@ -326,7 +326,7 @@ Arabel Pass.
 
 그래서 절반정도 먹긴 했지만 누텔라 병을 통째로 줬다.
 
-<ui-lazy-image cfId="a0cbf003-595c-4d0d-6549-2ced374d9700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a0cbf003-595c-4d0d-6549-2ced374d9700/post" />
 
 사실 돈을 좀 요구하셨었어도 드렸을거다.
 
@@ -338,11 +338,11 @@ Arabel Pass.
 
 겨울에는 있을 곳이 못 된다고.
 
-<ui-lazy-image cfId="640f45b0-33ce-48bb-1270-78df32e7a600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/640f45b0-33ce-48bb-1270-78df32e7a600/post" />
 
 자전거랑
 
-<ui-lazy-image cfId="c36a5db0-b74d-4ea1-1bde-c82ece53b200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c36a5db0-b74d-4ea1-1bde-c82ece53b200/post" />
 
 아까 떠나면서 받은 비상식량.
 
@@ -352,15 +352,15 @@ Arabel Pass.
 
 나는 뭐 먹을만 했는데, 정말 싫어하는 친구들도 여럿 만났다. ㅋㅋㅋ
 
-<ui-lazy-image cfId="b85c9fcb-b8a6-41d3-22fa-7e1082d98000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b85c9fcb-b8a6-41d3-22fa-7e1082d98000/post" />
 
-<ui-lazy-image cfId="dcc21ab8-065c-46c4-71a7-ec47b2d00300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/dcc21ab8-065c-46c4-71a7-ec47b2d00300/post" />
 
-<ui-lazy-image cfId="88d417ef-e1b7-410f-ed66-7a0754c6ba00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/88d417ef-e1b7-410f-ed66-7a0754c6ba00/post" />
 
-<ui-lazy-image cfId="98b78b9e-240f-40b8-44ce-b6a603f6d500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/98b78b9e-240f-40b8-44ce-b6a603f6d500/post" />
 
-<ui-lazy-image cfId="e682bb4a-facc-4834-3861-201e061ee100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e682bb4a-facc-4834-3861-201e061ee100/post" />
 
 드디어 나타난 슈퍼!
 
@@ -370,31 +370,31 @@ Arabel Pass.
 
 물건은 코카콜라나 과자 등 매우 단순한 것들이지만 콜라를 마실 수 있다는걸로 매우 행복했다.
 
-<ui-lazy-image cfId="b0986ceb-3009-4627-1a16-10ac03549d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b0986ceb-3009-4627-1a16-10ac03549d00/post" />
 
 뭔가 캠핑할 곳이 없어보이는 좁은 계곡인 것 같아 불안했는데...
 
-<ui-lazy-image cfId="0e5a48be-af2e-469c-936e-c6ec381f5c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0e5a48be-af2e-469c-936e-c6ec381f5c00/post" />
 
 다행히 좋은 곳을 찾았다.
 
 # 2018년 8월 15일
 
-<ui-lazy-image cfId="c928c019-b2ea-44c0-8e75-30389cd30400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c928c019-b2ea-44c0-8e75-30389cd30400/post" />
 
 이제 나린 계곡에 접어든다.
 
-<ui-lazy-image cfId="75458e53-3715-4dce-6ef7-d46a89d5f800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/75458e53-3715-4dce-6ef7-d46a89d5f800/post" />
 
 야영장 같은 곳도 눈에 들어오고, 사람들도 눈에 자주 띈다.
 
-<ui-lazy-image cfId="78117648-e038-4b74-ad3f-8d279b82f100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/78117648-e038-4b74-ad3f-8d279b82f100/post" />
 
-<ui-lazy-image cfId="ba74966b-3bb2-4563-3914-1868742f4100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ba74966b-3bb2-4563-3914-1868742f4100/post" />
 
-<ui-lazy-image cfId="ad3ebfad-8986-42e4-2166-f788eba51100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ad3ebfad-8986-42e4-2166-f788eba51100/post" />
 
-<ui-lazy-image cfId="2398b658-69c3-4784-3c5d-f4f927b5b100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2398b658-69c3-4784-3c5d-f4f927b5b100/post" />
 
 아이들은 자전거를 타고 있으면 돌을 잘 던진다.
 
@@ -406,11 +406,11 @@ Arabel Pass.
 
 ~~그래도 당하면 이 xx들이 하는 생각이 먼저 들긴 한다~~
 
-<ui-lazy-image cfId="220eb1dc-e9dd-42af-a269-9973b3283500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/220eb1dc-e9dd-42af-a269-9973b3283500/post" />
 
 나린.
 
-<ui-lazy-image cfId="12e30934-545d-4817-6056-773e065e3a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/12e30934-545d-4817-6056-773e065e3a00/post" />
 
 나린은 잘 알려진 곳인지 빈방을 찾는게 쉽지 않았다.
 

--- a/src/pages/posts/routes/2018-08-19~2018-09-07.md
+++ b/src/pages/posts/routes/2018-08-19~2018-09-07.md
@@ -8,87 +8,87 @@ countries: [KG]
 
 # 2018년 8월 19일
 
-<ui-lazy-image cfId="a9d411e3-7010-4254-b4aa-ccd935a5a800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a9d411e3-7010-4254-b4aa-ccd935a5a800/post" />
 
 나린 출발.
 
 비포장 도로 구간이 있지만 이 날은 그냥 포장 도로로 계속 달렸다.
 
-<ui-lazy-image cfId="8c99f41b-75b0-4fba-0cf5-de7585aaff00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8c99f41b-75b0-4fba-0cf5-de7585aaff00/post" />
 
 반대편에서 오던 친구들.
 
 같이 점심을 먹었다.
 
-<ui-lazy-image cfId="311149d0-f7bf-40c5-3b8e-f628b733ef00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/311149d0-f7bf-40c5-3b8e-f628b733ef00/post" />
 
 포장도로만 타서 그런지
 
-<ui-lazy-image cfId="591e8209-03d8-40cb-2af7-0ff2b5e0c300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/591e8209-03d8-40cb-2af7-0ff2b5e0c300/post" />
 
 좀 심심한 것.
 
-<ui-lazy-image cfId="0aeb1895-28f2-42eb-610c-66a513bcc500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0aeb1895-28f2-42eb-610c-66a513bcc500/post" />
 
 캠핑 오디서 하지...
 
 # 2018년 8월 20일
 
-<ui-lazy-image cfId="9272cb1b-e275-49e4-8507-685bd7d0d000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9272cb1b-e275-49e4-8507-685bd7d0d000/post" />
 
 Tash Rabat.
 
 어째서 이런 뜬금없는 곳에 지었을까 하는 논쟁이 남아있는 곳이다.
 
-<ui-lazy-image cfId="91deb7ef-2d92-4888-1339-1df27f531600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/91deb7ef-2d92-4888-1339-1df27f531600/post" />
 
 현재로서는 실크로드를 따라 이동하던 상인들이 머물다 가던 곳이라는 설이 가장 유력한데,
 
-<ui-lazy-image cfId="7eadb0f3-7c98-4052-8953-ad61635f5200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7eadb0f3-7c98-4052-8953-ad61635f5200/post" />
 
 그렇다기엔 좀 구석진 곳이란다.
 
 더 나은 곳도 많은데.
 
-<ui-lazy-image cfId="94847797-dde6-4d16-c043-dbed1e0dfb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/94847797-dde6-4d16-c043-dbed1e0dfb00/post" />
 
 그래서 여기는 모다! 라는 결론이 나지 않았다.
 
-<ui-lazy-image cfId="f7a9d5a7-9c25-4ea8-7923-136011ff1600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f7a9d5a7-9c25-4ea8-7923-136011ff1600/post" />
 
 그래, 유적은 이렇게 좀 오래된 느낌이 있어야지.
 
-<ui-lazy-image cfId="0c95fe62-7d64-4e6e-d072-7149ccc37f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0c95fe62-7d64-4e6e-d072-7149ccc37f00/post" />
 
 Tash Rabat으로 들어가는 길에는 크고 아름다운 바위들이 있다.
 
-<ui-lazy-image cfId="b0a87dba-8293-4d6c-cbb0-865cf401e200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b0a87dba-8293-4d6c-cbb0-865cf401e200/post" />
 
 자, 그럼 계속 갈 길 가볼까.
 
-<ui-lazy-image cfId="647be83e-38b4-4cf7-c6fb-b6ccb3368a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/647be83e-38b4-4cf7-c6fb-b6ccb3368a00/post" />
 
 여기 오토바이로 다녔나?
 
 바퀴 자국이 너무 깊게 패여져 있어서 오히려 라이딩 불가능...
 
-<ui-lazy-image cfId="2104a599-6eef-477f-c0eb-81bc92586500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2104a599-6eef-477f-c0eb-81bc92586500/post" />
 
 풀밭으로 달리려니 힘들다.
 
-<ui-lazy-image cfId="540dbf8d-0d22-49b5-7acf-820d211e5500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/540dbf8d-0d22-49b5-7acf-820d211e5500/post" />
 
 이 날 저녁은 어느 집에서 신세를 졌다.
 
 집이라기 보다는 그분도 잠깐씩 자고 가는 그런 곳인 것 같았는데,
 
-<ui-lazy-image cfId="0e25ea02-2be7-477f-b4a5-98b1c4f14500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0e25ea02-2be7-477f-b4a5-98b1c4f14500/post" />
 
 왜냐하면 이불을 꽤 오래 쓰지 않았는지 습기를 한껏 머금고 있었기 때문이다.
 
 자다가 몇 번 깼었는데, 마치 물 속에서 잠든 것 같은 느낌이었달까...
 
-<ui-lazy-image cfId="e794853f-e8dd-41ef-753c-342502e3b900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e794853f-e8dd-41ef-753c-342502e3b900/post" />
 
 참, 이 풍경 뒤에 Bikepacking에 올라온 GPS 경로가 부정확하다. (혹은 있던 길이 사라졌다.)
 
@@ -98,7 +98,7 @@ Tash Rabat으로 들어가는 길에는 크고 아름다운 바위들이 있다.
 
 # 2018년 8월 21일
 
-<ui-lazy-image cfId="ffc8d6be-f29b-4462-74a5-9c021b804c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ffc8d6be-f29b-4462-74a5-9c021b804c00/post" />
 
 가다가 어떤 자전거 여행자를 만났다.
 
@@ -114,7 +114,7 @@ Tash Rabat으로 들어가는 길에는 크고 아름다운 바위들이 있다.
 
 이 때에는 내 코스 보다 좀 더 길지만 많이 겹치던데, 이걸 2주 안에 주파해야 했다.
 
-<ui-lazy-image cfId="dd006785-312e-4b77-59c9-b8b096f84a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/dd006785-312e-4b77-59c9-b8b096f84a00/post" />
 
 방금 그 분이 1위. ㅋㅋㅋㅋㅋㅋㅋㅋ
 
@@ -122,35 +122,35 @@ Tash Rabat으로 들어가는 길에는 크고 아름다운 바위들이 있다.
 
 뒤따라오던 참가자들 몇 명과는 이야기 할 수 있었는데,
 
-<ui-lazy-image cfId="6d021a60-0e25-4624-b311-5626c73bc100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6d021a60-0e25-4624-b311-5626c73bc100/post" />
 
 하루에 4시간만 자고 계속 달리기만 한단다.
 
-<ui-lazy-image cfId="7615d023-5ee3-4ed9-989d-4caad2d55900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7615d023-5ee3-4ed9-989d-4caad2d55900/post" />
 
 밥도 자전거 위에서 먹고 그런다던데,
 
-<ui-lazy-image cfId="67a2e79e-5c47-4e48-5d3c-343479217700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/67a2e79e-5c47-4e48-5d3c-343479217700/post" />
 
 나처럼 게으른 라이더는 절대 불가.
 
-<ui-lazy-image cfId="fb15b3ec-202d-445a-dc10-06105f7a8700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/fb15b3ec-202d-445a-dc10-06105f7a8700/post" />
 
 이 분들은 자신의 한계와 계속 싸우고 있기 때문에
 
-<ui-lazy-image cfId="f2cc5db8-1c86-4db1-1486-60ff96a4a100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f2cc5db8-1c86-4db1-1486-60ff96a4a100/post" />
 
 가끔은 신경이 곤두서 있는 사람도 있다.
 
-<ui-lazy-image cfId="a59542ad-11de-4a7a-d72a-9712b632fe00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a59542ad-11de-4a7a-d72a-9712b632fe00/post" />
 
 만나면 그냥 모르는 척 해주자.
 
-<ui-lazy-image cfId="8b7edefd-be5d-461a-93e5-1e706fc6f300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8b7edefd-be5d-461a-93e5-1e706fc6f300/post" />
 
 이쪽으로 넘어왔더니 좀 사막 같은 풍경이다.
 
-<ui-lazy-image cfId="a7f1a49a-cb78-4208-47ae-3a6e8cd08800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a7f1a49a-cb78-4208-47ae-3a6e8cd08800/post" />
 
 Baetov 가서 띵가띵가해야지.
 
@@ -166,31 +166,31 @@ Baetov 가서 띵가띵가해야지.
 
 # 2018년 8월 23일
 
-<ui-lazy-image cfId="2a9780c7-6036-43cc-8c18-634828f74b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2a9780c7-6036-43cc-8c18-634828f74b00/post" />
 
 나도 휘리릭 하고 싶은데
 
-<ui-lazy-image cfId="5657901c-fb44-402d-1634-aa1b85e03800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5657901c-fb44-402d-1634-aa1b85e03800/post" />
 
 너무나 게으른 것.
 
-<ui-lazy-image cfId="a6f7d676-7763-4e3a-4398-5cae0d0af800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a6f7d676-7763-4e3a-4398-5cae0d0af800/post" />
 
 난 경치나 즐기면서 설렁설렁 가야지.
 
-<ui-lazy-image cfId="9f4aefc6-9c54-4b56-b54f-9e2e14248f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9f4aefc6-9c54-4b56-b54f-9e2e14248f00/post" />
 
 중간에 호주에서 온 커플을 만났는데,
 
-<ui-lazy-image cfId="3a529149-4985-4957-3de3-0410ea2b3a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3a529149-4985-4957-3de3-0410ea2b3a00/post" />
 
 역시나 앞질러 감.
 
-<ui-lazy-image cfId="90ae5f92-8fe7-463d-2bf9-4205364d1d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/90ae5f92-8fe7-463d-2bf9-4205364d1d00/post" />
 
 Moldo 고개를 넘기에는 시간이 부족한 것 같아 그 직전에 캠핑을 했다.
 
-<ui-lazy-image cfId="e4b2cc65-b00e-4846-4d35-c762e92ebf00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e4b2cc65-b00e-4846-4d35-c762e92ebf00/post" />
 
 그리고 저녁 요리 실패.
 
@@ -198,7 +198,7 @@ Moldo 고개를 넘기에는 시간이 부족한 것 같아 그 직전에 캠핑
 
 # 2018년 8월 24일
 
-<ui-lazy-image cfId="ee8413f1-f187-4b62-280d-95e979833b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ee8413f1-f187-4b62-280d-95e979833b00/post" />
 
 간밤에 그 맛없는 저녁을 먹고 자리에 누웠다.
 
@@ -214,7 +214,7 @@ Moldo 고개를 넘기에는 시간이 부족한 것 같아 그 직전에 캠핑
 
 대충 이런 뉘앙스의 대화였다.
 
-<ui-lazy-image cfId="91876e87-d7ff-4a28-4e48-53700e1c0800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/91876e87-d7ff-4a28-4e48-53700e1c0800/post" />
 
 아.. 가끔 캠핑을 하다 보면 그 장소가 하필 주변 사람들이 다니는 통로이거나 생활권인 경우가 종종 있다.
 
@@ -222,61 +222,61 @@ Moldo 고개를 넘기에는 시간이 부족한 것 같아 그 직전에 캠핑
 
 나도 그런 생각에 텐트 문을 열고 나왔다.
 
-<ui-lazy-image cfId="1280e45e-f774-432c-c15e-a82b5d8a9e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1280e45e-f774-432c-c15e-a82b5d8a9e00/post" />
 
 그런데 아무도 없었다.
 
-<ui-lazy-image cfId="7ef1caa7-a1bd-4be7-8437-071067aed800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7ef1caa7-a1bd-4be7-8437-071067aed800/post" />
 
 ... 이상하네
 
-<ui-lazy-image cfId="234cad0c-1282-48f2-c518-e3b156a92500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/234cad0c-1282-48f2-c518-e3b156a92500/post" />
 
 뭐, 일단 Moldo 고개 올라가야지.
 
-<ui-lazy-image cfId="6c38b0c5-f9cd-47a9-f57e-bd1f8504af00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6c38b0c5-f9cd-47a9-f57e-bd1f8504af00/post" />
 
 생각했던 것보다 쉬움.
 
-<ui-lazy-image cfId="6527d58a-c3a3-46be-6920-86c9c62c7300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6527d58a-c3a3-46be-6920-86c9c62c7300/post" />
 
 어제 헤어졌던 호주 커플도 다시 만났다.
 
-<ui-lazy-image cfId="f7b17ba0-3a7d-4012-1a0e-f1762f302600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f7b17ba0-3a7d-4012-1a0e-f1762f302600/post" />
 
 나보다 조금 일찍 정상에 도착해서 쉬고 있었다.
 
-<ui-lazy-image cfId="d79bc77d-c19c-44b0-b7e7-b1fba8658300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/d79bc77d-c19c-44b0-b7e7-b1fba8658300/post" />
 
 가운데 친구는 반대쪽에서 올라오던 친구.
 
-<ui-lazy-image cfId="eaf9d79f-7f7b-4da9-36cd-ddda47fd0e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/eaf9d79f-7f7b-4da9-36cd-ddda47fd0e00/post" />
 
 송쿨까지 함께 달린다.
 
-<ui-lazy-image cfId="7fafde5a-df00-4b5f-051f-0888ac9a5b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7fafde5a-df00-4b5f-051f-0888ac9a5b00/post" />
 
 송쿨의 날씨는 굉장히 변화무쌍했는데,
 
-<ui-lazy-image cfId="c141b925-becb-4726-f093-99d0dcfa3f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c141b925-becb-4726-f093-99d0dcfa3f00/post" />
 
 맑음, 흐림, 비, 우박, 돌풍 등등을 번갈아가며 풀세트로 체험할 수 있었다.
 
-<ui-lazy-image cfId="47fdf2e9-7000-4f19-b990-e2c5306ee900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/47fdf2e9-7000-4f19-b990-e2c5306ee900/post" />
 
 호주 커플은 송쿨에서 하룻밤 잔다고 하고, 나는 그대로 고고씽.
 
-<ui-lazy-image cfId="11d74a72-6680-4806-4f7e-6a3511d45200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/11d74a72-6680-4806-4f7e-6a3511d45200/post" />
 
 송쿨 그냥 넓기만 하고 날씨도 구리고 몽골에서 이미 이런거 많이 봤고
 
-<ui-lazy-image cfId="2fbf419d-0897-4011-77a2-65b11fcba100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2fbf419d-0897-4011-77a2-65b11fcba100/post" />
 
 빠르게 내려가는 선택을 해 봅니다.
 
 # 2018년 8월 25일
 
-<ui-lazy-image cfId="0b1fdd77-5917-4541-a018-82b97783ab00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0b1fdd77-5917-4541-a018-82b97783ab00/post" />
 
 다시 낮은 고도로 내려옴.
 
@@ -284,13 +284,13 @@ Moldo 고개를 넘기에는 시간이 부족한 것 같아 그 직전에 캠핑
 
 넘 더움. ㅠㅠ
 
-<ui-lazy-image cfId="8ec73f33-2496-4498-16f7-ae7d3fe9b000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8ec73f33-2496-4498-16f7-ae7d3fe9b000/post" />
 
 한 번 더 게을러져 본다.
 
 민박집 같은 곳.
 
-<ui-lazy-image cfId="39ef7d4e-9201-4e65-4f24-8665ededb900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/39ef7d4e-9201-4e65-4f24-8665ededb900/post" />
 
 애기들이 있고, 집 주인도 만삭이다.
 
@@ -298,7 +298,7 @@ Moldo 고개를 넘기에는 시간이 부족한 것 같아 그 직전에 캠핑
 
 # 2018년 8월 26일
 
-<ui-lazy-image cfId="13f8a32d-0aae-48c6-666d-109742697f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/13f8a32d-0aae-48c6-666d-109742697f00/post" />
 
 뭐 좀 구경하려고 나갔는데 일요일이라 한적했다.
 
@@ -312,7 +312,7 @@ Moldo 고개를 넘기에는 시간이 부족한 것 같아 그 직전에 캠핑
 
 뭐지 이 할아버지...
 
-<ui-lazy-image cfId="8ce75360-e0df-43a1-83d7-7d463515b100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8ce75360-e0df-43a1-83d7-7d463515b100/post" />
 
 나는 만삭인 여주인을 불러서 좀 도와달라는 표정을 짓는다.
 
@@ -334,79 +334,79 @@ Moldo 고개를 넘기에는 시간이 부족한 것 같아 그 직전에 캠핑
 
 # 2018년 8월 27일
 
-<ui-lazy-image cfId="26aa7c9a-0bf1-4cb8-c102-01ac70fe8d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/26aa7c9a-0bf1-4cb8-c102-01ac70fe8d00/post" />
 
 다시 출발.
 
-<ui-lazy-image cfId="0ac0b2d6-783a-490a-d794-3a77c687df00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0ac0b2d6-783a-490a-d794-3a77c687df00/post" />
 
 사실 어제 머물렀던 마을이 보급을 제대로 할 수 있는 마지막 포인트다. (아마도?)
 
-<ui-lazy-image cfId="289dd8d1-4532-435e-5b3e-6d1e53992600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/289dd8d1-4532-435e-5b3e-6d1e53992600/post" />
 
 그래서 짐이 한가득.
 
-<ui-lazy-image cfId="29b9f72e-43f9-4db8-c7f8-d34668751c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/29b9f72e-43f9-4db8-c7f8-d34668751c00/post" />
 
 여기 Kyzyl-Oi에도 슈퍼가 있는데 좀 작음.
 
-<ui-lazy-image cfId="12617fa9-c80b-465c-eb06-79b44511f000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/12617fa9-c80b-465c-eb06-79b44511f000/post" />
 
 점심으로 빵에 마요네즈를 발라먹는 클라스...
 
-<ui-lazy-image cfId="3bb8689e-f2f5-4c68-febe-22087c95b000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3bb8689e-f2f5-4c68-febe-22087c95b000/post" />
 
-<ui-lazy-image cfId="b36432db-45b4-4959-e8ce-19fad9af8500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b36432db-45b4-4959-e8ce-19fad9af8500/post" />
 
 이 계곡으로도 키르기스스탄 사람들 놀러 많이 오는 것 같았다.
 
-<ui-lazy-image cfId="cbefc6ed-fdd6-46ce-0ed6-403cddead700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/cbefc6ed-fdd6-46ce-0ed6-403cddead700/post" />
 
 물소리를 들으며 캠핑.
 
 # 2018년 8월 28일
 
-<ui-lazy-image cfId="46209c7c-279c-41d5-b742-411707043700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/46209c7c-279c-41d5-b742-411707043700/post" />
 
 오늘은 어디까지 갈 수 있을까.
 
-<ui-lazy-image cfId="bbab6c8a-8886-4bb8-9b72-a35a3e9e8d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bbab6c8a-8886-4bb8-9b72-a35a3e9e8d00/post" />
 
 가늠이 안 되네.
 
-<ui-lazy-image cfId="f73745bd-a153-46ea-7531-a846fdaae600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f73745bd-a153-46ea-7531-a846fdaae600/post" />
 
 반대쪽에서 오토바이를 타고 오던 이탈리아인을 만났다.
 
 서로 정보를 교환했다.
 
-<ui-lazy-image cfId="ba11433f-02fa-4534-0bf2-f35c6a602100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ba11433f-02fa-4534-0bf2-f35c6a602100/post" />
 
 Karakol 고개 직전에 있는 게르에 초대를 받았다.
 
-<ui-lazy-image cfId="380825d2-9854-4e64-0b1d-e8f0079a0800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/380825d2-9854-4e64-0b1d-e8f0079a0800/post" />
 
 말도 태워줬다.
 
-<ui-lazy-image cfId="4362e202-d937-45a6-244f-5928f0464400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4362e202-d937-45a6-244f-5928f0464400/post" />
 
 이 친구는 우즈베키스탄에서 와서 일을 하고 있었다.
 
-<ui-lazy-image cfId="1b5b02d2-8ca8-44e3-6980-8456ab088500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1b5b02d2-8ca8-44e3-6980-8456ab088500/post" />
 
 말을 타는 모습을 멋지게 보여줬다.
 
-<ui-lazy-image cfId="ae452d2c-37f3-4ab6-5c6c-ccb22a1bfe00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ae452d2c-37f3-4ab6-5c6c-ccb22a1bfe00/post" />
 
 새끼 강아지가 쉴새없이 큰 놈에게 덤비고 큰 놈은 받아주느라 피곤해했다. ㅋㅋㅋ
 
-<ui-lazy-image cfId="f76a5e9a-e3db-4d63-d6f8-b25c41942900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f76a5e9a-e3db-4d63-d6f8-b25c41942900/post" />
 
 그렇게 하루가 마무리된다.
 
 # 2018년 8월 29일
 
-<ui-lazy-image cfId="612fbdb6-daf3-4c8e-aa0a-2c017283aa00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/612fbdb6-daf3-4c8e-aa0a-2c017283aa00/post" />
 
 출근하는 양들.
 
@@ -414,123 +414,123 @@ Karakol 고개 직전에 있는 게르에 초대를 받았다.
 
 친구들은 말을 잡으러 뛰어다녔다.
 
-<ui-lazy-image cfId="3f541a5e-6f13-458e-334c-a1b12a0f6900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3f541a5e-6f13-458e-334c-a1b12a0f6900/post" />
 
 그 광경을 뒤로하고 나는 Karakol 고개를 넘었다.
 
-<ui-lazy-image cfId="7b27176f-2260-4cdb-5833-c47217170600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7b27176f-2260-4cdb-5833-c47217170600/post" />
 
 그리고 이 루트의 마지막 고개
 
-<ui-lazy-image cfId="5de21a7e-806d-49f1-419f-d76bc2eba200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5de21a7e-806d-49f1-419f-d76bc2eba200/post" />
 
 Kegety 고개가 보인다.
 
-<ui-lazy-image cfId="5b1cbb89-04ef-48e1-1b55-511f4224da00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5b1cbb89-04ef-48e1-1b55-511f4224da00/post" />
 
 실크로드 마운틴 레이스는 이 고개가 첫 번째 고개였다던데 (나와는 반대방향으로)
 
-<ui-lazy-image cfId="ddf10997-6042-4d0d-3c5d-a2b86a17e100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ddf10997-6042-4d0d-3c5d-a2b86a17e100/post" />
 
 여기서 기권자가 엄청 나왔다고 한다.
 
-<ui-lazy-image cfId="1cfd148e-373e-4ef2-c2b4-4ca18efc6100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1cfd148e-373e-4ef2-c2b4-4ca18efc6100/post" />
 
 반대 방향에서 오면 바로 3,000m 업힐에 지금 여기가 다운힐이 된다.
 
-<ui-lazy-image cfId="8eb2aef7-bf17-45cb-69b4-2d76562fd400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8eb2aef7-bf17-45cb-69b4-2d76562fd400/post" />
 
 아주 어렵다기 보다는 2주 안에 완주하는게 힘들 것 같다는 각이 이미 나오는거지...
 
-<ui-lazy-image cfId="927d4e38-e47f-4b85-b581-9dda884a0500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/927d4e38-e47f-4b85-b581-9dda884a0500/post" />
 
 그렇지 않아도 고개 올라오기 직전에 반대쪽에서 온 친구를 만났었다.
 
-<ui-lazy-image cfId="153e2e73-7857-48ae-e435-192533e5e700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/153e2e73-7857-48ae-e435-192533e5e700/post" />
 
 페니어 앞 뒤로 모두 달고 있는 전형적인 투어링 바이크 세팅이었는데 무사히 넘었다.
 
-<ui-lazy-image cfId="bb994ad1-e4ef-4a2d-7ef2-797fdfdc4b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bb994ad1-e4ef-4a2d-7ef2-797fdfdc4b00/post" />
 
 고개 반대편은 구름이 낀 듯 하다.
 
-<ui-lazy-image cfId="7775149c-72da-43ad-2bdc-deedef19a500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7775149c-72da-43ad-2bdc-deedef19a500/post" />
 
 거의 다 와 간다.
 
-<ui-lazy-image cfId="27937203-9e6e-4a36-593e-f00db2326600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/27937203-9e6e-4a36-593e-f00db2326600/post" />
 
 뒤를 돌아 내가 온 길도 한 번 보고
 
-<ui-lazy-image cfId="8550816d-9f81-4fb4-aaf9-264d737f6e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8550816d-9f81-4fb4-aaf9-264d737f6e00/post" />
 
 고개 정상!
 
-<ui-lazy-image cfId="c92d411d-97c5-4177-8451-19657dec1d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c92d411d-97c5-4177-8451-19657dec1d00/post" />
 
 카메라를 세팅하는 꾸밈없는 날 것 그대로의 사진.
 
-<ui-lazy-image cfId="6db10b3c-1775-41bb-ed6f-f20fe8eb8900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6db10b3c-1775-41bb-ed6f-f20fe8eb8900/post" />
 
 약간 폼 잡은 사진.
 
-<ui-lazy-image cfId="04b59f2d-67c8-4e5a-cdc0-485419418800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/04b59f2d-67c8-4e5a-cdc0-485419418800/post" />
 
 반대쪽도 경치가 좋다던데 구름이 껴서 보이지 않는다.
 
-<ui-lazy-image cfId="f5f12e70-eb60-4e34-2c2c-bd487090c400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f5f12e70-eb60-4e34-2c2c-bd487090c400/post" />
 
 내려가자!
 
-<ui-lazy-image cfId="faafc9f1-7362-48f5-ea1a-48f4712c5b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/faafc9f1-7362-48f5-ea1a-48f4712c5b00/post" />
 
 구름 아래로 내려오니 조금씩 보이기 시작한다.
 
-<ui-lazy-image cfId="d620b0a3-2dfe-4363-eab5-b56438f7ca00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/d620b0a3-2dfe-4363-eab5-b56438f7ca00/post" />
 
 최대한 고도 낮추고 자야지.
 
-<ui-lazy-image cfId="2ae03f69-7f04-461f-b80c-318da1608600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2ae03f69-7f04-461f-b80c-318da1608600/post" />
 
 이 때 선택을 잘못했다.
 
 다음날 날씨 좋았는데...
 
-<ui-lazy-image cfId="b019ca78-221e-41a3-0a33-f920f2452700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b019ca78-221e-41a3-0a33-f920f2452700/post" />
 
 위에서 캠핑했으면 경치를 볼 수 있었을거다.
 
 # 2018년 8월 30일
 
-<ui-lazy-image cfId="447718b7-50b7-4f36-daca-7b3e9659ae00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/447718b7-50b7-4f36-daca-7b3e9659ae00/post" />
 
 좀 경사진 데에서 캠핑을 해서 그런가 컨디션이 별로군.
 
-<ui-lazy-image cfId="59a1d083-623a-49d4-33ec-4869bb66d400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/59a1d083-623a-49d4-33ec-4869bb66d400/post" />
 
 스토브 연료가 다 떨어졌지만 오늘 비슈케크에 들어갈테니 문제 없겠지?
 
-<ui-lazy-image cfId="6493b625-8b57-4065-58ca-c52c2a8da800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6493b625-8b57-4065-58ca-c52c2a8da800/post" />
 
 기분 좋은 내리막이 계속된다.
 
-<ui-lazy-image cfId="b91278ff-4fe4-4d72-459f-aca4a72b1e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b91278ff-4fe4-4d72-459f-aca4a72b1e00/post" />
 
 교통체증.
 
-<ui-lazy-image cfId="17769385-ff67-406d-6827-694bc5454800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/17769385-ff67-406d-6827-694bc5454800/post" />
 
 말들이 놀래서 흩어지면 안되니 좁은 길에서는 추월을 못 했...
 
-<ui-lazy-image cfId="bb8a2789-f27d-473a-5b94-79943647d400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bb8a2789-f27d-473a-5b94-79943647d400/post" />
 
 산을 다 내려왔다.
 
-<ui-lazy-image cfId="dc3feb69-e00f-4098-4903-a0b6191c3d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/dc3feb69-e00f-4098-4903-a0b6191c3d00/post" />
 
 이제 비슈케크로 향한다.
 
-<ui-lazy-image cfId="46d05288-599f-4cc8-7013-de2d8c88af00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/46d05288-599f-4cc8-7013-de2d8c88af00/post" />
 
 점심을 굶었더니 배가 너무 고팠다.
 
@@ -538,18 +538,18 @@ Kegety 고개가 보인다.
 
 # 2018년 8월 31일 ~ 2018년 9월 7일
 
-<ui-lazy-image cfId="eea26d97-f2a1-413d-287f-7e831f37d800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/eea26d97-f2a1-413d-287f-7e831f37d800/post" />
 
 꽤 오랫동안 쉬었다.
 
 하지만 파미르를 눈 오기 전에 넘으려면 더 쉴 수는 없지.
 
-<ui-lazy-image cfId="87ffc829-f7e1-4895-2f94-d8e1487c0200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/87ffc829-f7e1-4895-2f94-d8e1487c0200/post" />
 
 뭔가 겨울 장비를 보충할까싶어 바자르에 갔는데 좀 늦었다.
 
 파장이네.
 
-<ui-lazy-image cfId="b2fbc180-0b9a-4ae8-8412-3b8cea579200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b2fbc180-0b9a-4ae8-8412-3b8cea579200/post" />
 
 다시 짐을 싼다.

--- a/src/pages/posts/routes/2018-09-08~2018-09-20.md
+++ b/src/pages/posts/routes/2018-09-08~2018-09-20.md
@@ -8,79 +8,79 @@ countries: [KG]
 
 # 2018년 9월 8일
 
-<ui-lazy-image cfId="0ad67f6f-c4eb-4c35-ebd4-de64f6cc8800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0ad67f6f-c4eb-4c35-ebd4-de64f6cc8800/post" />
 
 사실 Osh 까지 버스 타려고 했다.
 
 그래서 버스 타는 곳으로 가고 있었다.
 
-<ui-lazy-image cfId="4f563aa9-6e94-471b-b8d5-d07364cb5000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4f563aa9-6e94-471b-b8d5-d07364cb5000/post" />
 
 그런데 생각해 보니 버스에 타는게 귀찮은 거였다.
 
 자전거 분해하고, 가방도 다 떼어내고, 흥정하고...
 
-<ui-lazy-image cfId="3d5ede71-dd8b-4d90-6273-414a29d9c500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3d5ede71-dd8b-4d90-6273-414a29d9c500/post" />
 
 그래서 그냥 자전거 타고 가기로 했다.
 
-<ui-lazy-image cfId="53d4398f-dd07-4578-f32a-5a641154b200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/53d4398f-dd07-4578-f32a-5a641154b200/post" />
 
 나의 게으름과 귀차니즘으로
 
-<ui-lazy-image cfId="4165cb20-3dbf-45bf-4a1b-3d9c259ea500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4165cb20-3dbf-45bf-4a1b-3d9c259ea500/post" />
 
 2,500미터 업힐.
 
 # 2018년 9월 9일
 
-<ui-lazy-image cfId="8333b131-de02-4e2a-d06c-1d074d886500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8333b131-de02-4e2a-d06c-1d074d886500/post" />
 
 휴, 어찌저찌 적당한 공간을 발견해서 캠핑에 성공.
 
-<ui-lazy-image cfId="9218430f-006a-4148-3dc1-afb18c728b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9218430f-006a-4148-3dc1-afb18c728b00/post" />
 
 판쵸 입고 셀카.
 
-<ui-lazy-image cfId="98d407e3-450f-4774-e7b2-1e5633870400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/98d407e3-450f-4774-e7b2-1e5633870400/post" />
 
 그 동안 단련이 돼서 그런지
 
-<ui-lazy-image cfId="bd5e34a4-d569-4da3-57cb-4e00f3301800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bd5e34a4-d569-4da3-57cb-4e00f3301800/post" />
 
 힘은 드는데 다리는 계속 돌아간다.
 
-<ui-lazy-image cfId="161fb9ad-3c4c-41bc-cf71-2a6d5f681000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/161fb9ad-3c4c-41bc-cf71-2a6d5f681000/post" />
 
 이 고개 끝에는 악명 높은 터널이 있는데,
 
-<ui-lazy-image cfId="c23b99b9-0b6d-469d-afe6-9abbad915a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c23b99b9-0b6d-469d-afe6-9abbad915a00/post" />
 
 자전거를 타고 들어가는건 매우매우매우 비추천이다.
 
 너무 좁아서 일방통행인 터널이고, 무엇보다 환기 시설이 전혀 없어서 매연으로 가득 차있다.
 
-<ui-lazy-image cfId="4fb07395-abd2-41be-5ca3-8a73c4e9f900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4fb07395-abd2-41be-5ca3-8a73c4e9f900/post" />
 
 차를 얻어타거나 옛 길로 가면 된다.
 
 물론 옛 길로 가면 비포장에 고개 정상을 찍고 오는 거다.
 
-<ui-lazy-image cfId="8c3c69af-c67d-42b0-5825-69d2d073bc00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8c3c69af-c67d-42b0-5825-69d2d073bc00/post" />
 
 이제는 그 길로 통행하는 차가 없어서 전혀 관리가 안 되고 있다는데 자세한 건 현지에서 확인이 필요하다.
 
-<ui-lazy-image cfId="ce4259a6-d50b-46fb-e21b-6eb978707400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ce4259a6-d50b-46fb-e21b-6eb978707400/post" />
 
 으... 난 그냥 얻어타야지.
 
-<ui-lazy-image cfId="3d0fe153-1430-4e07-320a-f8c088d61300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3d0fe153-1430-4e07-320a-f8c088d61300/post" />
 
 생각보다 오래 기다렸지만 트럭 한 대에 자전거를 싣고 터널을 통과할 수 있었다.
 
 의외로 자전거를 실을만한 트럭이 잘 오지 않았다.
 
-<ui-lazy-image cfId="177f5705-8b70-445c-6875-8bd384ae6e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/177f5705-8b70-445c-6875-8bd384ae6e00/post" />
 
 고개를 내려가서 좀 쉬려고 자전거에서 내리려 했다.
 
@@ -90,7 +90,7 @@ countries: [KG]
 
 # 2018년 9월 10일
 
-<ui-lazy-image cfId="7f84c6d7-ac26-4ee3-b753-7117541c5800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7f84c6d7-ac26-4ee3-b753-7117541c5800/post" />
 
 흐림.
 
@@ -98,19 +98,19 @@ countries: [KG]
 
 우박 1번.
 
-<ui-lazy-image cfId="cace7ab9-c9d9-48ec-6c42-0b9f135d1400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/cace7ab9-c9d9-48ec-6c42-0b9f135d1400/post" />
 
 소나기가 장대비로 내릴 때가 있었는데, 이분들 집 안으로 피신할 수 있었다.
 
 고맙습니다!
 
-<ui-lazy-image cfId="8974ce22-a52c-46dd-a9af-2f26f5085c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8974ce22-a52c-46dd-a9af-2f26f5085c00/post" />
 
 우박은 다리 밑에서 피하고, Ala-bel 고개를 넘는다.
 
 이 고도에서는 벌써 나뭇잎이 울긋불긋해서 마음이 더 급해졌다.
 
-<ui-lazy-image cfId="70c5898f-fafe-41aa-394a-20b75e2b7900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/70c5898f-fafe-41aa-394a-20b75e2b7900/post" />
 
 다운힐 하다가 힘들어서 쉬엄쉬엄 내려가는건 또 오랜만이네.
 
@@ -122,77 +122,77 @@ countries: [KG]
 
 # 2018년 9월 11일
 
-<ui-lazy-image cfId="db5f0b4d-ddd0-4a90-536f-ba762cfa2900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/db5f0b4d-ddd0-4a90-536f-ba762cfa2900/post" />
 
 넓직한 공터 좋아요.
 
-<ui-lazy-image cfId="87625d26-2fdb-4abe-443f-bc92f0812000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/87625d26-2fdb-4abe-443f-bc92f0812000/post" />
 
 늦여름의
 
-<ui-lazy-image cfId="7b7e300e-4a64-474d-4ab5-c3e974acbc00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7b7e300e-4a64-474d-4ab5-c3e974acbc00/post" />
 
 Toktogul 저수지.
 
-<ui-lazy-image cfId="d02d5a74-f3cb-48cc-6d90-ba41e2b35200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/d02d5a74-f3cb-48cc-6d90-ba41e2b35200/post" />
 
-<ui-lazy-image cfId="7c04a895-5570-4820-c1d1-e11a11466300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7c04a895-5570-4820-c1d1-e11a11466300/post" />
 
-<ui-lazy-image cfId="194d7973-27a3-47ec-1898-432e236d8800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/194d7973-27a3-47ec-1898-432e236d8800/post" />
 
-<ui-lazy-image cfId="8d9c7b5d-8bf2-4c19-c6ae-7c26b1cd4100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8d9c7b5d-8bf2-4c19-c6ae-7c26b1cd4100/post" />
 
-<ui-lazy-image cfId="61f14594-87f8-4d9c-7b1c-a7bd2e74e900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/61f14594-87f8-4d9c-7b1c-a7bd2e74e900/post" />
 
 슬슬 캠핑할 곳을 탐색하던 찰나
 
-<ui-lazy-image cfId="85060a49-8564-4ddd-b8de-8eea6d4c1f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/85060a49-8564-4ddd-b8de-8eea6d4c1f00/post" />
 
-<ui-lazy-image cfId="78cc891e-c1b3-4c4d-3fd4-3ce74e7dee00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/78cc891e-c1b3-4c4d-3fd4-3ce74e7dee00/post" />
 
 모텔을 발견했다.
 
-<ui-lazy-image cfId="bebe295d-399a-4a7f-ace4-221af9ba3200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bebe295d-399a-4a7f-ace4-221af9ba3200/post" />
 
 이뻐서 여기서 묶기로 했다.
 
-<ui-lazy-image cfId="87115f64-62a0-4757-9d20-43482636d100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/87115f64-62a0-4757-9d20-43482636d100/post" />
 
 단, 샤워 불가.
 
-<ui-lazy-image cfId="f1d1968c-8b2f-4d63-8152-a43ede257b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f1d1968c-8b2f-4d63-8152-a43ede257b00/post" />
 
 고장나서 고치는 중이란다.
 
 # 2018년 9월 12일
 
-<ui-lazy-image cfId="ec788cf2-68d1-406c-fdde-4955ac58ac00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ec788cf2-68d1-406c-fdde-4955ac58ac00/post" />
 
 오늘은 협곡을 통과하게 되는데
 
-<ui-lazy-image cfId="2c843b0e-3458-4c6b-befc-608a8299da00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2c843b0e-3458-4c6b-befc-608a8299da00/post" />
 
 터널이 많다.
 
-<ui-lazy-image cfId="a4c9dafc-2277-43f1-f850-f76a1d274800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a4c9dafc-2277-43f1-f850-f76a1d274800/post" />
 
 불빛도 없지만
 
-<ui-lazy-image cfId="b37374bb-4192-4fc1-b974-7b506a93ed00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b37374bb-4192-4fc1-b974-7b506a93ed00/post" />
 
 다행히 짧고 차도 별로 없어서 문제는 없었음.
 
-<ui-lazy-image cfId="01b17972-b0fd-4117-8349-200f7c848d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/01b17972-b0fd-4117-8349-200f7c848d00/post" />
 
 이 협곡을 지나고나면 인구밀도가 높은 지역이 시작된다.
 
-<ui-lazy-image cfId="4b6bffd2-0171-40d3-c90a-60d3062fbe00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4b6bffd2-0171-40d3-c90a-60d3062fbe00/post" />
 
 좋지 않음.
 
 # 2018년 9월 13일
 
-<ui-lazy-image cfId="4da973f0-8090-4f73-cd14-640162213a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4da973f0-8090-4f73-cd14-640162213a00/post" />
 
 차와 사람이 많아진다.
 
@@ -202,19 +202,19 @@ Toktogul 저수지.
 
 # 2018년 9월 15 ~ 17일
 
-<ui-lazy-image cfId="88890fde-7951-4889-8aea-67bde2f4dd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/88890fde-7951-4889-8aea-67bde2f4dd00/post" />
 
 Osh에서 쉬는 동안 두 가지 일을 처리했는데,
 
-<ui-lazy-image cfId="5eb087b8-7de8-45f0-6865-d6a2b98fc100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5eb087b8-7de8-45f0-6865-d6a2b98fc100/post" />
 
 먼저 충분한 타지키스탄 현금을 확보하는 것과,
 
-<ui-lazy-image cfId="a789b6f5-bf31-49dc-fdde-5472cfde2d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a789b6f5-bf31-49dc-fdde-5472cfde2d00/post" />
 
 이 물건을 받는 일이었다.
 
-<ui-lazy-image cfId="2099bdeb-9639-4e35-9a0e-6f4530a42e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2099bdeb-9639-4e35-9a0e-6f4530a42e00/post" />
 
 예전에 비슈케크에서 만났던 이탈리아인 발렌티나의 물건인데,
 
@@ -226,52 +226,52 @@ Osh에서 쉬는 동안 두 가지 일을 처리했는데,
 
 # 2018년 9월 18일
 
-<ui-lazy-image cfId="8b8d7345-ae09-47bd-83bf-db9be1b7fa00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8b8d7345-ae09-47bd-83bf-db9be1b7fa00/post" />
 
 Osh를 출발하고 만난 친구들.
 
-<ui-lazy-image cfId="a16b36bd-cf83-45b4-8f67-94c363384500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a16b36bd-cf83-45b4-8f67-94c363384500/post" />
 
 이 날 밤에 캠핑도 같이 했다.
 
 # 2018년 9월 1데일
 
-<ui-lazy-image cfId="9b968ff1-a98b-44aa-8242-a7e061ebc200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/9b968ff1-a98b-44aa-8242-a7e061ebc200/post" />
 
 어제 만난 친구들은 고장난 카메라 고친다고 다시 돌아갔다.
 
-<ui-lazy-image cfId="8f2a8f95-045d-4677-1e67-08c62bfa7700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8f2a8f95-045d-4677-1e67-08c62bfa7700/post" />
 
 다시 혼자서 페달을 굴린다.
 
-<ui-lazy-image cfId="54b91506-6f72-4bc2-233f-f304a6bf9e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/54b91506-6f72-4bc2-233f-f304a6bf9e00/post" />
 
 고개 끝까지 올라가려다 마침 돌더미 뒤에 공간이 있길래 캠핑.
 
 # 2018년 9월 20일
 
-<ui-lazy-image cfId="ab92b29d-fb06-4d84-aa5b-b88aa9b10500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ab92b29d-fb06-4d84-aa5b-b88aa9b10500/post" />
 
 산 때문에 햇빛이 늦게 들어온다.
 
-<ui-lazy-image cfId="ac86240e-8056-4f94-84de-51b23ba86600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ac86240e-8056-4f94-84de-51b23ba86600/post" />
 
 예전에는 꽤 험한 구간이었다던데
 
-<ui-lazy-image cfId="738b7cf4-db1c-4de0-7398-429cd0b9a900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/738b7cf4-db1c-4de0-7398-429cd0b9a900/post" />
 
 이제는 포장도로가 잘 깔였다.
 
-<ui-lazy-image cfId="29d5c455-6345-4173-31cc-b21351578400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/29d5c455-6345-4173-31cc-b21351578400/post" />
 
 여기 다운힐에서 땀이 식으면서 좀 으슬으슬했는데
 
 짧은 구간이라 괜찮겠지 하는 생각에 그냥 옷 안 꺼내입고 내달렸다.
 
-<ui-lazy-image cfId="ac45bd0c-8651-420c-f63d-2b88cddf5f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ac45bd0c-8651-420c-f63d-2b88cddf5f00/post" />
 
 파미르에서 감기몸살로 고생하는데 아마 여기서 걸렸던 것 같다.
 
-<ui-lazy-image cfId="1faffe0e-6b4f-4523-3951-d95b3f12fd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1faffe0e-6b4f-4523-3951-d95b3f12fd00/post" />
 
 그렇게 Sary-Tash 도착.

--- a/src/pages/posts/routes/2018-09-21~2018-10-02.md
+++ b/src/pages/posts/routes/2018-09-21~2018-10-02.md
@@ -8,71 +8,71 @@ countries: [KG, TJ]
 
 # 2018년 9월 21일
 
-<ui-lazy-image cfId="ec1c761c-6030-4672-1157-db47767f2700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ec1c761c-6030-4672-1157-db47767f2700/post" />
 
 Sary-Tash 출발
 
-<ui-lazy-image cfId="2656d018-1e1d-44c8-c03e-3bbc737ec400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2656d018-1e1d-44c8-c03e-3bbc737ec400/post" />
 
 본격적으로 파미르로 들어간다.
 
-<ui-lazy-image cfId="2931796a-f625-45c8-bddb-d78b67b00400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2931796a-f625-45c8-bddb-d78b67b00400/post" />
 
 Sary-Tash 에서는 식량 보급이 좀 어렵다.
 
-<ui-lazy-image cfId="5ba06626-9f2d-4730-c7c3-1f16f12e2800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5ba06626-9f2d-4730-c7c3-1f16f12e2800/post" />
 
 마늘이랑 양파랑 이런 것만 샀음 ㅠㅠ
 
-<ui-lazy-image cfId="ae9f1b7a-e330-4b96-a904-bb9a31ec6e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ae9f1b7a-e330-4b96-a904-bb9a31ec6e00/post" />
 
 더 큰 문제는 여기가 Rushon 전 마지막 주유소라는 점인데
 
-<ui-lazy-image cfId="27eba51b-db67-4ff6-5926-3fb5f733d900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/27eba51b-db67-4ff6-5926-3fb5f733d900/post" />
 
 스토브 불 조절을 섬세하게 해서 연료를 아껴야겠다.
 
-<ui-lazy-image cfId="12910517-ede8-4c64-96eb-58066ae9e500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/12910517-ede8-4c64-96eb-58066ae9e500/post" />
 
 뭐, 그렇긴 한데 또 가보니깐 어떻게든 휘발유를 구하려면 구할 수 있겠더라.
 
-<ui-lazy-image cfId="b00c5a5e-4f4a-453d-d971-4aaf9aede400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b00c5a5e-4f4a-453d-d971-4aaf9aede400/post" />
 
 그리고 무르갑쪽으로 빠지는 사람들에게는 큰 문제는 아니다.
 
-<ui-lazy-image cfId="f6fb787c-8799-4ff4-0754-7b782521b600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f6fb787c-8799-4ff4-0754-7b782521b600/post" />
 
 여름 다 지나서 좀 황량한 듯.
 
-<ui-lazy-image cfId="b42029b4-eb0a-469d-db2e-e388e1eb6200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b42029b4-eb0a-469d-db2e-e388e1eb6200/post" />
 
 키르기스스탄 국경을 지나고 타지키스탄 국경까지는 갭이 좀 있다.
 
-<ui-lazy-image cfId="a3422ab8-dd83-4450-f7d4-4d4953645300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a3422ab8-dd83-4450-f7d4-4d4953645300/post" />
 
 키르기스스탄에서 머무는 동안 시간을 알차게 보낸 것 같아 기분이가 좋다.
 
-<ui-lazy-image cfId="ed64cebe-a34c-430c-8a4b-19ca07f4ad00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ed64cebe-a34c-430c-8a4b-19ca07f4ad00/post" />
 
-<ui-lazy-image cfId="2b1a2d47-f8fe-499c-fd33-204a3a725600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2b1a2d47-f8fe-499c-fd33-204a3a725600/post" />
 
 아무래도 타지키스탄 국경까지 가기엔 좀 무리고 그 전에 자야할 것 같은데
 
-<ui-lazy-image cfId="19044473-da90-495a-2e25-e80416b17800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/19044473-da90-495a-2e25-e80416b17800/post" />
 
 집이 있네?
 
 # 2018년 9월 22일
 
-<ui-lazy-image cfId="73962a05-e530-4140-c516-6e0db8d74000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/73962a05-e530-4140-c516-6e0db8d74000/post" />
 
 집에는 마침 다른 자전거 여행자들도 있어서 같이 밤을 보냈다.
 
-<ui-lazy-image cfId="d6b6f1e6-dcfb-45c0-1a74-5024dc9cbd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/d6b6f1e6-dcfb-45c0-1a74-5024dc9cbd00/post" />
 
 저 친구들은 키르기스스탄으로 향한다.
 
-<ui-lazy-image cfId="3485bb12-e431-4ec1-c568-198cf97c1d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3485bb12-e431-4ec1-c568-198cf97c1d00/post" />
 
 집주인은 가끔씩 이곳에 와서 이렇게 여행자들을 대상으로 부업을 하시는 것 같았다.
 
@@ -82,121 +82,121 @@ Sary-Tash 에서는 식량 보급이 좀 어렵다.
 
 어제 저녁에 우리 밥 해주시느라 식량을 다 썼는지 아침을 안 드시길래 우리가 좀 나눠드림.
 
-<ui-lazy-image cfId="c992d1b1-0ed8-4ba4-d507-59b4d2fb0000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c992d1b1-0ed8-4ba4-d507-59b4d2fb0000/post" />
 
 저 고개를 넘으면 타지키스탄 국경이 있다.
 
-<ui-lazy-image cfId="3fd19ef4-f125-4165-920b-324145bbe700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3fd19ef4-f125-4165-920b-324145bbe700/post" />
 
 사진으로 많이 본 석상인데 생각보다 크네.
 
-<ui-lazy-image cfId="1da9d2fa-f325-4725-7bca-bcf79c410500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1da9d2fa-f325-4725-7bca-bcf79c410500/post" />
 
 타지키스탄 국경 검문소의 군인들은 그리 친절하지 않다.
 
-<ui-lazy-image cfId="8d30f895-2ffc-4505-e3c8-6f39c5eb9e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8d30f895-2ffc-4505-e3c8-6f39c5eb9e00/post" />
 
 사진이 얼마 없지만 뭔가 지구가 아닌 것 같은 풍경.
 
-<ui-lazy-image cfId="f963d34e-6404-493f-018a-330722ea2f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f963d34e-6404-493f-018a-330722ea2f00/post" />
 
-<ui-lazy-image cfId="a5c5ff7e-7114-492f-4e85-d0ece3eecd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a5c5ff7e-7114-492f-4e85-d0ece3eecd00/post" />
 
 드디어 카라콜 호수가 보인다.
 
-<ui-lazy-image cfId="e8bfdb05-6736-480a-94b2-4fc56e656800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e8bfdb05-6736-480a-94b2-4fc56e656800/post" />
 
 이번 포스트는 뭔가 텐션이 좀 떨어지는데
 
-<ui-lazy-image cfId="7c5fec07-44a9-490c-d66a-60ef1ee98600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7c5fec07-44a9-490c-d66a-60ef1ee98600/post" />
 
 뭐라 할 말이 없어서다.
 
-<ui-lazy-image cfId="d3b675b9-e828-4a25-c3e0-36eaad7f3c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/d3b675b9-e828-4a25-c3e0-36eaad7f3c00/post" />
 
 사진도 여기를 표현 못하고, 내 글은 더 못하고.
 
-<ui-lazy-image cfId="eb7110bf-b484-4bd3-8a47-6e8924291200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/eb7110bf-b484-4bd3-8a47-6e8924291200/post" />
 
 막 아름답고 아기자기 예쁘고 그렇지는 않고
 
-<ui-lazy-image cfId="26977332-87e1-4e86-e7a1-9a07af249700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/26977332-87e1-4e86-e7a1-9a07af249700/post" />
 
 그냥 크고 넓다.
 
-<ui-lazy-image cfId="3a8b14ba-424b-4325-bf46-069889e25000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3a8b14ba-424b-4325-bf46-069889e25000/post" />
 
 그레서 내가 작아지는 것 같다.
 
-<ui-lazy-image cfId="b3628f05-5d93-4b7a-76fd-e991f3d34f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b3628f05-5d93-4b7a-76fd-e991f3d34f00/post" />
 
 커지는 것 같기도 하고
 
-<ui-lazy-image cfId="6d7e7731-fbb9-4c2e-e6b7-a4260d4b0500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6d7e7731-fbb9-4c2e-e6b7-a4260d4b0500/post" />
 
 이상한 동네임.
 
-<ui-lazy-image cfId="8e4bde8e-c683-40c9-5d01-ac948f88f200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8e4bde8e-c683-40c9-5d01-ac948f88f200/post" />
 
 오토바이 여행자 만나서 정보 공유 중.
 
-<ui-lazy-image cfId="c34e6999-06e4-4c1c-7ea5-9c210768aa00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c34e6999-06e4-4c1c-7ea5-9c210768aa00/post" />
 
 광활한 경치를 카메라가 못 잡으니
 
-<ui-lazy-image cfId="ef3c7fb7-33ec-4402-ee23-1fc535b3c900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ef3c7fb7-33ec-4402-ee23-1fc535b3c900/post" />
 
 이런 거 찍음.
 
-<ui-lazy-image cfId="17e78ff1-c0c9-45db-d090-be4055630500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/17e78ff1-c0c9-45db-d090-be4055630500/post" />
 
 에라이 ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ
 
-<ui-lazy-image cfId="39e1035d-227f-4d00-8fd9-2349a6684000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/39e1035d-227f-4d00-8fd9-2349a6684000/post" />
 
 근데 기억이 잘 안 난다.
 
-<ui-lazy-image cfId="14c24bc4-0387-436e-cc62-211c477c1d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/14c24bc4-0387-436e-cc62-211c477c1d00/post" />
 
 고산증도 조금 있었던 듯.
 
-<ui-lazy-image cfId="bc959e20-948b-42c9-816e-78a5407a5300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bc959e20-948b-42c9-816e-78a5407a5300/post" />
 
 카라콜 도착.
 
-<ui-lazy-image cfId="84f69ea2-b0c6-490a-0c04-ef03648b1400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/84f69ea2-b0c6-490a-0c04-ef03648b1400/post" />
 
 민박을 하는 곳이 있어서 들어갔다.
 
-<ui-lazy-image cfId="4d0b78aa-cb70-453f-50d6-b50aba1a6d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4d0b78aa-cb70-453f-50d6-b50aba1a6d00/post" />
 
 식량이랑 스토브 연료가 좀 제한적이어서 이런 데 있을 때 열심히 들어가야지.
 
-<ui-lazy-image cfId="34b0d032-da35-4e17-a086-3311f847d000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/34b0d032-da35-4e17-a086-3311f847d000/post" />
 
 # 2018년 9월 23일
 
-<ui-lazy-image cfId="ad481ab9-7700-4d44-bed0-09ddb6155400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ad481ab9-7700-4d44-bed0-09ddb6155400/post" />
 
 왜
 
-<ui-lazy-image cfId="3db42694-216c-4251-8407-3144e9b11800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3db42694-216c-4251-8407-3144e9b11800/post" />
 
 나한테는 항상 맞바람인가.
 
-<ui-lazy-image cfId="d0e9e70b-93fc-4a0c-b67d-6bf37669ea00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/d0e9e70b-93fc-4a0c-b67d-6bf37669ea00/post" />
 
 모자를 저기에 씌어놓은 이는 또 누구며
 
-<ui-lazy-image cfId="50f1896a-1d9b-4dd5-b648-b93552bf3900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/50f1896a-1d9b-4dd5-b648-b93552bf3900/post" />
 
 나는 왜 또 편한 길 두고
 
-<ui-lazy-image cfId="ce054a1d-4609-4d9a-27d6-1ea904113300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ce054a1d-4609-4d9a-27d6-1ea904113300/post" />
 
 Bartang Valley로 기어들어가는가
 
-<ui-lazy-image cfId="d3666442-b136-48a9-39d6-ea0f97a9a200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/d3666442-b136-48a9-39d6-ea0f97a9a200/post" />
 
 도하 ㄱㄱ
 
@@ -216,138 +216,138 @@ Bartang Valley로 기어들어가는가
 
 # 2018년 9월 24일
 
-<ui-lazy-image cfId="623b5824-ba44-47ec-4ad6-37ac78f6ff00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/623b5824-ba44-47ec-4ad6-37ac78f6ff00/post" />
 
 잠을 자지 못했다.
 
-<ui-lazy-image cfId="48de418e-e164-4f42-ab95-cb27ef794800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/48de418e-e164-4f42-ab95-cb27ef794800/post" />
 
 텐트 날아가는 줄.
 
-<ui-lazy-image cfId="342739de-3d3e-4f9a-648a-ca82064cbd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/342739de-3d3e-4f9a-648a-ca82064cbd00/post" />
 
 바닥에 고정시켰던 팩들이 팅~ 팅~ 소리를 내며 빠졌고
 
-<ui-lazy-image cfId="728fe958-751e-4000-7317-e80cafc8ad00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/728fe958-751e-4000-7317-e80cafc8ad00/post" />
 
 오직 내 몸뚱아리만이 텐트가 날아가는 걸 막고 있었다.
 
-<ui-lazy-image cfId="c82b537c-e3fa-4d35-ee75-9b614794c100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c82b537c-e3fa-4d35-ee75-9b614794c100/post" />
 
 풍향도 그냥 동서남북에서 다 불던데 ㅋㅋㅋㅋ
 
-<ui-lazy-image cfId="8140261b-8bf1-4e4e-9b06-f8415bdf2e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8140261b-8bf1-4e4e-9b06-f8415bdf2e00/post" />
 
 누군가가 살았던 흔적.
 
-<ui-lazy-image cfId="6a100a5c-c439-4db2-aeff-62a406c99100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6a100a5c-c439-4db2-aeff-62a406c99100/post" />
 
 여기서 캠핑도 더 하고 좀 더 머물고 싶은데
 
-<ui-lazy-image cfId="5e9b3bcb-310d-4448-4fb1-2bca858a7000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5e9b3bcb-310d-4448-4fb1-2bca858a7000/post" />
 
 빨리 내려가야 할 것 같다.
 
 몸 상태가 좋지 않음.
 
-<ui-lazy-image cfId="13e8e3ce-f5a0-4b1b-b145-6cc7fa240c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/13e8e3ce-f5a0-4b1b-b145-6cc7fa240c00/post" />
 
 셀카나 찍어야지.
 
-<ui-lazy-image cfId="c0533ad2-87ae-42db-7257-a58af38bd300" />
-<ui-lazy-image cfId="46f93499-6940-42ca-9856-abdac485e200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c0533ad2-87ae-42db-7257-a58af38bd300/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/46f93499-6940-42ca-9856-abdac485e200/post" />
 
-<ui-lazy-image cfId="6ef43820-ac8a-4ea5-1b8d-f3bc61848200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6ef43820-ac8a-4ea5-1b8d-f3bc61848200/post" />
 
 나는 Rushon(Rushan) 방향으로!
 
-<ui-lazy-image cfId="31c78264-1140-4664-b40d-4f9daadb3800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/31c78264-1140-4664-b40d-4f9daadb3800/post" />
 
 쩝... 너무 아쉽...
 
-<ui-lazy-image cfId="68def83c-5025-4937-1460-0602d0347500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/68def83c-5025-4937-1460-0602d0347500/post" />
 
 해 질 때까지 냅다 달려서 낮은 고도로 내려옴.
 
-<ui-lazy-image cfId="292d1589-fdd9-454d-8a16-f8f72c313a00" />
-<ui-lazy-image cfId="ee450de4-217b-441d-f7f0-a2fd965adb00" />
-<ui-lazy-image cfId="ec3d8a15-1b5e-4e8c-9ae9-757316e31500" />
-<ui-lazy-image cfId="1a4e7d26-56a9-48b2-8a99-2a0112dc2100" />
-<ui-lazy-image cfId="e847e4d8-140b-4447-80e1-4cd4aaae4b00" /> -->
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/292d1589-fdd9-454d-8a16-f8f72c313a00/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ee450de4-217b-441d-f7f0-a2fd965adb00/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ec3d8a15-1b5e-4e8c-9ae9-757316e31500/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/1a4e7d26-56a9-48b2-8a99-2a0112dc2100/post" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e847e4d8-140b-4447-80e1-4cd4aaae4b00/post" /> -->
 
-<ui-lazy-image cfId="3d69a56e-b851-4303-aaeb-2c6523acbe00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3d69a56e-b851-4303-aaeb-2c6523acbe00/post" />
 
 그게 해발 3,300m 인거는 함정.
 
 # 2018년 9월 25일
 
-<ui-lazy-image cfId="aa94832e-d6c4-4a05-1f7e-c2b9584caf00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/aa94832e-d6c4-4a05-1f7e-c2b9584caf00/post" />
 
 아, 조용한 밤이었다.
 
-<ui-lazy-image cfId="2be91059-3e2c-45ca-eef9-77828c7bbd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2be91059-3e2c-45ca-eef9-77828c7bbd00/post" />
 
-<ui-lazy-image cfId="6910e6bf-c699-4180-7197-b615b2002d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6910e6bf-c699-4180-7197-b615b2002d00/post" />
 
-<ui-lazy-image cfId="edc18b48-397c-4f1f-7191-b7c1796a0d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/edc18b48-397c-4f1f-7191-b7c1796a0d00/post" />
 
-<ui-lazy-image cfId="b4a79834-e0d7-470d-f496-3f51eda73200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b4a79834-e0d7-470d-f496-3f51eda73200/post" />
 
-<ui-lazy-image cfId="90721697-51d6-46d9-4b6f-fef9564e0100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/90721697-51d6-46d9-4b6f-fef9564e0100/post" />
 
 살 것 같네.
 
-<ui-lazy-image cfId="3530da54-b486-4b92-313f-f48cea569e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3530da54-b486-4b92-313f-f48cea569e00/post" />
 
 더 이상 할 말도 없으니
 
-<ui-lazy-image cfId="b99866cf-567f-43e7-4e75-fd1cb2e12800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b99866cf-567f-43e7-4e75-fd1cb2e12800/post" />
 
 풍경이나 감상하도록 하죠.
 
-<ui-lazy-image cfId="92c41b45-234d-4bf7-f261-731162d54f00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/92c41b45-234d-4bf7-f261-731162d54f00/post" />
 
-<ui-lazy-image cfId="7784f4da-bf58-48d9-2d02-affa3bd6d800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7784f4da-bf58-48d9-2d02-affa3bd6d800/post" />
 
-<ui-lazy-image cfId="8709440c-d7b3-418e-36e0-53d4dc6d8500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8709440c-d7b3-418e-36e0-53d4dc6d8500/post" />
 
-<ui-lazy-image cfId="57d6a63d-5d7d-42bb-6407-4f0f4cac1c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/57d6a63d-5d7d-42bb-6407-4f0f4cac1c00/post" />
 
-<ui-lazy-image cfId="f4e891b9-38b7-4382-eaba-8cfb807ffb00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f4e891b9-38b7-4382-eaba-8cfb807ffb00/post" />
 
-<ui-lazy-image cfId="3674ea02-3e53-483d-40c4-41a948893c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3674ea02-3e53-483d-40c4-41a948893c00/post" />
 
-<ui-lazy-image cfId="b1ec8810-a3ea-40f6-6e70-a88bcd1ca400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b1ec8810-a3ea-40f6-6e70-a88bcd1ca400/post" />
 
-<ui-lazy-image cfId="3d6ace80-1d73-4631-6d7b-1d2104016300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3d6ace80-1d73-4631-6d7b-1d2104016300/post" />
 
-<ui-lazy-image cfId="657fd95a-2aa2-4dd5-10ad-faef546bb400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/657fd95a-2aa2-4dd5-10ad-faef546bb400/post" />
 
-<ui-lazy-image cfId="e7f7b0d0-d644-4bf0-415f-52176ce12300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/e7f7b0d0-d644-4bf0-415f-52176ce12300/post" />
 
-<ui-lazy-image cfId="62fdc5e7-5654-4507-995f-a2e186ac8000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/62fdc5e7-5654-4507-995f-a2e186ac8000/post" />
 
-<ui-lazy-image cfId="bd0b83d0-3513-447f-2f3a-9a56f8f4ef00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/bd0b83d0-3513-447f-2f3a-9a56f8f4ef00/post" />
 
-<ui-lazy-image cfId="f703429d-d4dc-45c0-16af-fcd7b489f300" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f703429d-d4dc-45c0-16af-fcd7b489f300/post" />
 
-<ui-lazy-image cfId="7ee01471-c243-46be-10ab-f373116d0100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7ee01471-c243-46be-10ab-f373116d0100/post" />
 
-<ui-lazy-image cfId="f49385a1-a0fd-4aaa-9737-b98af6ce1d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f49385a1-a0fd-4aaa-9737-b98af6ce1d00/post" />
 
-<ui-lazy-image cfId="ff57f33f-98de-4dfb-ca1d-b32ccc0e4000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ff57f33f-98de-4dfb-ca1d-b32ccc0e4000/post" />
 
-<ui-lazy-image cfId="7d4d0eb3-345f-4d68-c2c0-75bd9904ec00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7d4d0eb3-345f-4d68-c2c0-75bd9904ec00/post" />
 
-<ui-lazy-image cfId="5e84c233-33b4-4609-4fd6-53b52a181800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5e84c233-33b4-4609-4fd6-53b52a181800/post" />
 
-<ui-lazy-image cfId="990086c4-5aa4-4359-3cab-250a02d59b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/990086c4-5aa4-4359-3cab-250a02d59b00/post" />
 
-<ui-lazy-image cfId="821d41e9-09fe-4d75-35a8-2e1f575e7b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/821d41e9-09fe-4d75-35a8-2e1f575e7b00/post" />
 
-<ui-lazy-image cfId="eb73a478-726f-418c-4ff6-4fd13979f400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/eb73a478-726f-418c-4ff6-4fd13979f400/post" />
 
-<ui-lazy-image cfId="7661d524-f0f8-4408-881b-04ef64819900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7661d524-f0f8-4408-881b-04ef64819900/post" />
 
 Gudara 도착
 
@@ -355,41 +355,41 @@ Gudara 도착
 
 # 2018년 9월 26일
 
-<ui-lazy-image cfId="a86bab63-d66c-435a-2a59-79a492dfc000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/a86bab63-d66c-435a-2a59-79a492dfc000/post" />
 
 좋지 않아 좋지 않아
 
-<ui-lazy-image cfId="304774b8-9b45-4cb3-392f-fb7c87b86800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/304774b8-9b45-4cb3-392f-fb7c87b86800/post" />
 
 회복이 안 된다.
 
-<ui-lazy-image cfId="6456cc66-7c28-4546-2413-9f2b7acd3d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/6456cc66-7c28-4546-2413-9f2b7acd3d00/post" />
 
 약간 몸에 한계가 온 느낌.
 
-<ui-lazy-image cfId="fca7a4da-9fc2-47d2-dd4a-471148fc9d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/fca7a4da-9fc2-47d2-dd4a-471148fc9d00/post" />
 
 Pasor로 가서 그 위쪽으로 탐사해 보려던 계획도 취소.
 
-<ui-lazy-image cfId="05ff31c4-2747-48de-b26c-35a372e7f600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/05ff31c4-2747-48de-b26c-35a372e7f600/post" />
 
 콜록 콜록
 
-<ui-lazy-image cfId="2370184b-9fd0-4711-1706-060e6a3a1a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2370184b-9fd0-4711-1706-060e6a3a1a00/post" />
 
 쿨럭 쿨럭
 
-<ui-lazy-image cfId="887db0f3-d48e-4135-3b66-27431aacb500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/887db0f3-d48e-4135-3b66-27431aacb500/post" />
 
 Savnob 도착
 
-<ui-lazy-image cfId="ddd62aca-c7e4-469e-5a62-3f2b7ef87b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ddd62aca-c7e4-469e-5a62-3f2b7ef87b00/post" />
 
 마을의 젊은이들.
 
 왼쪽에서 두 번째 친구가 숙소를 운영하고 있었다.
 
-<ui-lazy-image cfId="72f96a28-83af-4dd8-2873-1400eead1e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/72f96a28-83af-4dd8-2873-1400eead1e00/post" />
 
 영어가 서로 완벽하진 않았지만 내가 이해한 바로는:
 
@@ -397,103 +397,103 @@ Savnob 도착
 
 사진 속의 나머지 친구들도 러시아 등등 각지로 나가서 일하는데, 잠시 고향에 돌아와 있는 것이다.
 
-<ui-lazy-image cfId="2db31a7b-6a35-4471-29ec-f7df68c59400" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/2db31a7b-6a35-4471-29ec-f7df68c59400/post" />
 
 이 한산해 보이는 마을도 한 때는 지금 인구의 2 ~ 3배는 되는 사람들이 북적였으려나.
 
-<ui-lazy-image cfId="c5faa602-4fe9-4c11-dbfc-41b899b17800" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c5faa602-4fe9-4c11-dbfc-41b899b17800/post" />
 
 숙소.
 
 의외로 나같은 여행객 말고도 머물다 가는 사람들이 있더라.
 
-<ui-lazy-image cfId="7c79b4ea-417c-4314-16c6-ba7aba0cd600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7c79b4ea-417c-4314-16c6-ba7aba0cd600/post" />
 
 양말도 하나 삼.
 
 # 2018년 9월 27일
 
-<ui-lazy-image cfId="4ddf0acc-23b7-404d-eb3e-c78e56ed0e00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4ddf0acc-23b7-404d-eb3e-c78e56ed0e00/post" />
 
 Savnob 안녕~
 
-<ui-lazy-image cfId="97d13325-c156-4b26-63af-5b86de312200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/97d13325-c156-4b26-63af-5b86de312200/post" />
 
 멀리서 본 Savnob.
 
-<ui-lazy-image cfId="aebec98b-b3d1-483f-e984-deb08cb2d000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/aebec98b-b3d1-483f-e984-deb08cb2d000/post" />
 
 뭔가 헬기 착륙장 같은 곳?
 
-<ui-lazy-image cfId="0a7a0611-4dd6-4467-9e99-8a279b4a6000" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0a7a0611-4dd6-4467-9e99-8a279b4a6000/post" />
 
 근데 여기 마을들은 멀리서 보면
 
-<ui-lazy-image cfId="7f1f9dca-55ac-445f-69ff-1d7d8e498700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/7f1f9dca-55ac-445f-69ff-1d7d8e498700/post" />
 
 정말 예쁘다.
 
-<ui-lazy-image cfId="d5cbb1e6-1d4f-4321-c741-4310d59aa500" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/d5cbb1e6-1d4f-4321-c741-4310d59aa500/post" />
 
 산사태로 원래 길이 끊겨서
 
-<ui-lazy-image cfId="f2a5e937-ea88-4862-c0f5-b2adec979700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/f2a5e937-ea88-4862-c0f5-b2adec979700/post" />
 
 일단 이렇게 강을 가로지르는 길을 만들어 놨다.
 
-<ui-lazy-image cfId="8feaaa82-f526-42ba-67d4-0fc968849200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/8feaaa82-f526-42ba-67d4-0fc968849200/post" />
 
 산사태도 빈번하고
 
-<ui-lazy-image cfId="0f927fb9-b62b-44ac-3850-8a81b90ff900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0f927fb9-b62b-44ac-3850-8a81b90ff900/post" />
 
 특히 초여름에 오는 경우엔 불어난 강물로
 
-<ui-lazy-image cfId="c103dc90-573f-450a-0936-a2a60ad58d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c103dc90-573f-450a-0936-a2a60ad58d00/post" />
 
 길의 많은 부분이 침수된다고 하니 주의가 필요하다.
 
-<ui-lazy-image cfId="63891605-730c-4453-05c2-4993c2de2700" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/63891605-730c-4453-05c2-4993c2de2700/post" />
 
 그 때문인지 길가에 이런 장비들이 놓여 있음.
 
 # 2018년 9월 28일
 
-<ui-lazy-image cfId="11b69d54-fe75-4ea3-f356-dfbb93628600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/11b69d54-fe75-4ea3-f356-dfbb93628600/post" />
 
 어젯밤에도 숙소에서 잤는데 어디였지? Basid 였나?
 
-<ui-lazy-image cfId="16e043f8-5867-4ce1-6b60-e22e34877a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/16e043f8-5867-4ce1-6b60-e22e34877a00/post" />
 
 고도가 내려가니 낮에는 좀 덥네.
 
-<ui-lazy-image cfId="06bcf823-edd1-4f99-bcc6-db3b4e37de00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/06bcf823-edd1-4f99-bcc6-db3b4e37de00/post" />
 
 그런 의미로 물에 잠긴 도로로 가볼까.
 
-<ui-lazy-image cfId="c62c3cb1-c285-40e6-6adb-043dfb5cde00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/c62c3cb1-c285-40e6-6adb-043dfb5cde00/post" />
 
 아차차 너무 깊은데 라고 생각이 들었지만 이미 늦었기에 강행돌파.
 
-<ui-lazy-image cfId="56973025-f351-479d-a6b0-e958d5ab7200" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/56973025-f351-479d-a6b0-e958d5ab7200/post" />
 
 따라하지 마세요. 위로 돌아가는 길을 이용하세요.
 
-<ui-lazy-image cfId="95a7a565-1073-46c3-e13e-cfa54128cf00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/95a7a565-1073-46c3-e13e-cfa54128cf00/post" />
 
 저는 돌아가기 귀찮아서...
 
 # 2018년 9월 29일
 
-<ui-lazy-image cfId="93526b5d-0a2f-4be8-c461-2c7c30c14c00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/93526b5d-0a2f-4be8-c461-2c7c30c14c00/post" />
 
 캠핑할 곳이 없어서 방황하던 찰나 한 분이 나를 재워주셨다.
 
-<ui-lazy-image cfId="27e42797-9b47-45cf-d0a1-38a213b62900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/27e42797-9b47-45cf-d0a1-38a213b62900/post" />
 
 아저씨랑 저 평상 위에서 잤음.
 
-<ui-lazy-image cfId="4c07338a-fd99-4354-7529-c752e9dc5600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/4c07338a-fd99-4354-7529-c752e9dc5600/post" />
 
 이 물로 세수도 하고,
 
@@ -501,37 +501,37 @@ Savnob 안녕~
 
 음, 타지키스탄에서 먹었던 음식 중 제일 맛있었던 듯.
 
-<ui-lazy-image cfId="431225b3-154c-4762-0ba1-b1653cbbb900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/431225b3-154c-4762-0ba1-b1653cbbb900/post" />
 
 아저씨의 아이들.
 
-<ui-lazy-image cfId="91972b2a-e691-4946-daac-368618b04d00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/91972b2a-e691-4946-daac-368618b04d00/post" />
 
-<ui-lazy-image cfId="053f2fe5-e380-4d80-6a9d-928b3b2c0b00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/053f2fe5-e380-4d80-6a9d-928b3b2c0b00/post" />
 
 저 멀리 산이 보인다.
 
 저 산은 아프가니스탄이다.
 
-<ui-lazy-image cfId="3298d9be-69a1-4813-f947-d09cde00ae00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3298d9be-69a1-4813-f947-d09cde00ae00/post" />
 
 즉, Bartang Valley도 이제 끝이다.
 
 좀 급하게 내려왔어야 해서 아쉬움이 크다.
 
-<ui-lazy-image cfId="ed663fc1-e7d5-42b6-e481-84b5e4a8ae00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/ed663fc1-e7d5-42b6-e481-84b5e4a8ae00/post" />
 
 호두 따던 분들에게서 받음.
 
-<ui-lazy-image cfId="0134fb28-077e-4d4c-e2d1-6cb2f53a7600" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/0134fb28-077e-4d4c-e2d1-6cb2f53a7600/post" />
 
 드디어 주도로에 합류한다.
 
-<ui-lazy-image cfId="b1c5c5d3-e610-4d10-5772-4a0cae715900" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/b1c5c5d3-e610-4d10-5772-4a0cae715900/post" />
 
 호두 또 받음.
 
-<ui-lazy-image cfId="3cf28a6b-308c-4a22-b602-d57e5efa0a00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/3cf28a6b-308c-4a22-b602-d57e5efa0a00/post" />
 
 어떤 꼬마한테서 자동차도 받음.
 
@@ -551,13 +551,13 @@ Rushon에서 머물면서 여러 일을 처리했다.
 
 떠나기 전 날 보드카 사와서 마셨다.
 
-<ui-lazy-image cfId="5abc40c5-80da-433c-3fa5-0d06af88cd00" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5abc40c5-80da-433c-3fa5-0d06af88cd00/post" />
 
 호스텔 관리하시던 분.
 
 술은 안 하심.
 
-<ui-lazy-image cfId="5a34ccfe-1cc6-4222-847b-de98f7046100" />
+<ui-lazy-image src="https://imagedelivery.net/fOEhHq_KNsIgC-hb-3NU0w/5a34ccfe-1cc6-4222-847b-de98f7046100/post" />
 
 홍콩에서 온 여행자.
 


### PR DESCRIPTION
# Description and Context

 <!-- What should others know about this code? -->

1. After upgrading packages, `<ui-lazy-image />` inside markdown files does not understand custom props like `cfId` anymore. So these are replaced to full image urls as `src`. 
2. Additionally, manual lazy loading via Intersection Observer in `<ui-lazy-image />` is removed. Now the browser will determine lazy loading images. 

# Operating Systems

<!-- What kind of OS did you use for development? -->

- [x] OSX
- [ ] WSL 2
- [ ] Windows
- [ ] Other (please describe):

# Browsers Tested

<!-- What kind of browsers have you tested? -->

- [x] Chrome
- [ ] Firefox
- [ ] Safari

# Test Instructions

 <!-- How to see your changes, what to look out for. -->

# Screenshots

 <!-- If your code introduces a visual change, include screenshots showing the UI before and after -->

# Types of changes

 <!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New Post
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Style (style changes)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional/api changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Build-related change (change to the build process or configuration)
- [ ] Documentation change (adding or updating project documentation)
- [ ] Test (changes related to unit test, component test, e2e test)
- [ ] Other (please describe):
